### PR TITLE
Implement more advanced pluralization rules

### DIFF
--- a/src/AI/prompt-system.txt
+++ b/src/AI/prompt-system.txt
@@ -5,7 +5,8 @@ Follow these important rules first
 - [IMPORTANT] Keep the html entity characters the same usage, and the same position. (e.g. &laquo; &raquo; &lt; &gt; &amp;, ...)
 - Keep the punctuation same. Don't remove or add any punctuation.
 - Keep the words starting with ':', '@' and '/' the original. Or sometimes wrapped with '{', '}'. They are variables or commands.
-- Keep pluralization code same. (e.g. {0} There are none|[1,19] There are some|[20,*] There are many)
+- Keep precise pluralization code with numbers same (e.g. {0} There are none|[1,19] There are some|[20,*] There are many), but if in {sourceLanguage} there are only singular + one plural form of the phrase separated by a single pipe (e.g. people|person), and in {targetLanguage} should be more then add corresponding translations separated by a pipe sign (e.g. osoba|osoby|osób) and preserve case of letters for each. Don't add plural forms by yourself if there is no need for it (no pluralization in {sourceLanguage}).
+- Keep a letter case for each word like in source translation. The only exception would be when {targetLanguage} has different capitalization rules than {sourceLanguage} for example for some languages nouns should be capitalized.
 - For phrases or titles without a period, translate them directly without adding extra words or changing the structure.
     - Examples:
     - 'Read in other languages' should be translated as a phrase or title, without adding extra words.


### PR DESCRIPTION
Hi, 

In some languages like Polish ([see more](https://github.com/illuminate/translation/blob/8500f436869866e9157d3be9013b2e32dee28c78/MessageSelector.php#L108)) there are more than one plural form of a single word. 

E.g. `person|people` should be translated into `osoba|osoby|osób`.

More examples (and valid results):

```php
[
    'files_count' => '[1] File|[2,4] Files|[5,*] Files',
    'person_count' => 'Person|People',
    'ball_count' => 'ball|balls',
    'coach_single' => 'coach',
]

[
  'files_count' => '[1] Plik|[2,4] Pliki|[5,*] Plików',
  'person_count' => 'Osoba|Osoby|Osób',
  'ball_count' => 'piłka|piłki|piłek',
  'coach_single' => 'trener',
]
```

I tried adding this prompt as an additional rule but it didn't work because it conflicts in some way with the main rule. Anyway it it is not a case only for Polish so IMHO this rule should be global to make it work for all possible languages.

Tested using the `claude-3-sonnet-20240229` model. 