### PR TITLE
Update TranslateStrings.php - Add CLI options and force flag

### DIFF
--- a/config/ai-translator.php
+++ b/config/ai-translator.php
@@ -33,6 +33,9 @@ return [
 
     // 'disable_plural' => true,
     // 'skip_locales' => [],
+    
+    // If set to true, translations will be saved as flat arrays using dot notation keys. If set to false, translations will be saved as multi-dimensional arrays.
+    'dot_notation' => true,
 
     // You can add additional custom locale names here.
     // Example: 'en_us', 'en-us', 'en_US', 'en-US'

--- a/src/Console/TranslateStrings.php
+++ b/src/Console/TranslateStrings.php
@@ -15,16 +15,25 @@ use Kargnas\LaravelAiTranslator\Enums\PromptType;
 /**
  * Command to translate PHP language files using AI technology
  */
+/**
+ * Command to translate PHP language files using AI technology
+ */
 class TranslateStrings extends Command
 {
     protected $signature = 'ai-translator:translate 
         {--l|locale=* : Specific locales to translate (e.g. --locale=ko,ja). If not provided, will ask interactively}
-        {--show-prompt : Show AI prompts during translation}';
+        {--s|source= : Source language to translate from (e.g. --source=en)}
+        {--r|reference=* : Reference languages for translation guidance (e.g. --reference=fr,es)}
+        {--c|chunk= : Chunk size for translation (e.g. --chunk=100)}
+        {--m|max-context= : Maximum number of context items to include (e.g. --max-context=1000)}
+        {--show-prompt : Show AI prompts during translation}
+        {--f|force : Skip all confirmations}
+        {--non-interactive : Run in non-interactive mode, using default or provided values}';
 
     protected $description = 'Translates PHP language files using AI technology';
 
     /**
-     * 번역 관련 설정
+     * Translation settings
      */
     protected string $sourceLocale;
     protected string $sourceDirectory;
@@ -32,7 +41,7 @@ class TranslateStrings extends Command
     protected array $referenceLocales = [];
 
     /**
-     * 토큰 사용량 추적
+     * Token usage tracking
      */
     protected array $tokenUsage = [
         'input_tokens' => 0,
@@ -41,7 +50,7 @@ class TranslateStrings extends Command
     ];
 
     /**
-     * 컬러 코드
+     * Color codes
      */
     protected array $colors = [
         'reset' => "\033[0m",
@@ -65,7 +74,7 @@ class TranslateStrings extends Command
     ];
 
     /**
-     * 생성자
+     * Constructor
      */
     public function __construct()
     {
@@ -82,44 +91,80 @@ class TranslateStrings extends Command
     }
 
     /**
-     * 커맨드 실행 메인 메서드
+     * Main command execution method
      */
     public function handle()
     {
-        // 헤더 출력
+        // Display header
         $this->displayHeader();
 
-        // 소스 디렉토리 설정
+        // Set source directory
         $this->sourceDirectory = config('ai-translator.source_directory');
 
-        // 소스 언어 선택
-        $this->sourceLocale = $this->choiceLanguages(
-            $this->colors['yellow'] . "Choose a source language to translate from" . $this->colors['reset'],
-            false,
-            'en'
-        );
+        // Check if running in non-interactive mode
+        $nonInteractive = $this->option('non-interactive');
 
-        // 레퍼런스 언어 선택
-        if ($this->ask($this->colors['yellow'] . 'Do you want to add reference languages? (y/n)' . $this->colors['reset'], 'n') === 'y') {
+        // Select source language
+        if ($nonInteractive || $this->option('source')) {
+            $this->sourceLocale = $this->option('source') ?? config('ai-translator.source_locale', 'en');
+            $this->info($this->colors['green'] . "✓ Selected source locale: " .
+                $this->colors['reset'] . $this->colors['bold'] . $this->sourceLocale .
+                $this->colors['reset']);
+        } else {
+            $this->sourceLocale = $this->choiceLanguages(
+                $this->colors['yellow'] . "Choose a source language to translate from" . $this->colors['reset'],
+                false,
+                'en'
+            );
+        }
+
+        // Select reference languages
+        if ($nonInteractive) {
+            $this->referenceLocales = $this->option('reference') ?? [];
+            if (!empty($this->referenceLocales)) {
+                $this->info($this->colors['green'] . "✓ Selected reference locales: " .
+                    $this->colors['reset'] . $this->colors['bold'] . implode(', ', $this->referenceLocales) .
+                    $this->colors['reset']);
+            }
+        } else if ($this->option('reference')) {
+            $this->referenceLocales = $this->option('reference');
+            $this->info($this->colors['green'] . "✓ Selected reference locales: " .
+                $this->colors['reset'] . $this->colors['bold'] . implode(', ', $this->referenceLocales) .
+                $this->colors['reset']);
+        } else if ($this->ask($this->colors['yellow'] . 'Do you want to add reference languages? (y/n)' . $this->colors['reset'], 'n') === 'y') {
             $this->referenceLocales = $this->choiceLanguages(
                 $this->colors['yellow'] . "Choose reference languages for translation guidance. Select languages with high-quality translations. Multiple selections with comma separator (e.g. '1,2')" . $this->colors['reset'],
                 true
             );
         }
 
-        // 청크 사이즈 설정
-        $this->chunkSize = (int) $this->ask(
-            $this->colors['yellow'] . "Enter the chunk size for translation. Translate strings in a batch. The higher, the cheaper." . $this->colors['reset'],
-            100
-        );
+        // Set chunk size
+        if ($nonInteractive || $this->option('chunk')) {
+            $this->chunkSize = (int) ($this->option('chunk') ?? 100);
+            $this->info($this->colors['green'] . "✓ Chunk size: " .
+                $this->colors['reset'] . $this->colors['bold'] . $this->chunkSize .
+                $this->colors['reset']);
+        } else {
+            $this->chunkSize = (int) $this->ask(
+                $this->colors['yellow'] . "Enter the chunk size for translation. Translate strings in a batch. The higher, the cheaper." . $this->colors['reset'],
+                100
+            );
+        }
 
-        // 컨텍스트 항목 수 설정
-        $maxContextItems = (int) $this->ask(
-            $this->colors['yellow'] . "Maximum number of context items to include for consistency (set 0 to disable)" . $this->colors['reset'],
-            1000
-        );
+        // Set context items count
+        if ($nonInteractive || $this->option('max-context')) {
+            $maxContextItems = (int) ($this->option('max-context') ?? 1000);
+            $this->info($this->colors['green'] . "✓ Maximum context items: " .
+                $this->colors['reset'] . $this->colors['bold'] . $maxContextItems .
+                $this->colors['reset']);
+        } else {
+            $maxContextItems = (int) $this->ask(
+                $this->colors['yellow'] . "Maximum number of context items to include for consistency (set 0 to disable)" . $this->colors['reset'],
+                1000
+            );
+        }
 
-        // 번역 실행
+        // Execute translation
         $this->translate($maxContextItems);
 
         return 0;
@@ -250,8 +295,8 @@ class TranslateStrings extends Command
                 $localeStringCount += count($sourceStringList);
                 $totalStringCount += count($sourceStringList);
 
-                // 많은 문자열이 있을 경우 확인
-                if (count($sourceStringList) > 500) {
+                // Check if there are many strings to translate
+                if (count($sourceStringList) > 500 && !$this->option('force')) {
                     if (
                         !$this->confirm(
                             $this->colors['yellow'] . "⚠️ Warning: " . $this->colors['reset'] .

--- a/src/Transformers/PHPLangTransformer.php
+++ b/src/Transformers/PHPLangTransformer.php
@@ -2,39 +2,75 @@
 
 namespace Kargnas\LaravelAiTranslator\Transformers;
 
+use Illuminate\Support\Facades\Config;
+
 /**
  * Example of content of $filePath:
  * <?php
  *
  * return [
- * 'title' => [
- * 'blog' => 'Sangrak\'s Blog',
- * ],
+ *   'title' => [
+ *     'blog' => 'Sangrak\'s Blog',
+ *   ],
  * ];
  */
 class PHPLangTransformer
 {
+    private array $originalContent = [];
+
+    private array $flattenedContent = [];
+
+    private bool $useDotNotation;
+
     public function __construct(
         public string $filePath,
     ) {
+        $this->useDotNotation = Config::get('ai-translator.dot_notation', false);
+        $this->loadOriginalContent();
+        $this->flattenedContent = $this->flatten();
     }
 
-    public function isTranslated($key)
+    /**
+     * Load original content from file
+     */
+    private function loadOriginalContent(): void
     {
-        $flatten = $this->flatten();
-        return array_key_exists($key, $flatten);
+        if (file_exists($this->filePath)) {
+            $this->originalContent = require $this->filePath;
+        } else {
+            $this->originalContent = [];
+        }
     }
 
+    /**
+     * Check if a key is already translated
+     *
+     * @param string $key Key in dot notation
+     * @return bool
+     */
+    public function isTranslated(string $key): bool
+    {
+        return array_key_exists($key, $this->flattenedContent);
+    }
+
+    /**
+     * Flatten a nested array to dot notation
+     *
+     * @return array
+     */
     public function flatten(): array
     {
-        if (!file_exists($this->filePath)) {
-            return [];
-        }
-        $content = require $this->filePath;
-        return $this->flattenArray($content);
+        return $this->flattenArray($this->originalContent);
     }
 
-    public function flattenArray($content, $prefix = ''): array
+    /**
+     * Recursive function to flatten an array with dot notation
+     *
+     * @param array $content Content to flatten
+     * @param string $prefix Prefix for keys
+     * @return array
+     */
+    public function flattenArray(array $content, string $prefix = ''): array
     {
         $flattened = [];
         foreach ($content as $key => $value) {
@@ -47,10 +83,119 @@ class PHPLangTransformer
         return $flattened;
     }
 
-    public function updateString(string $key, string $translated)
+    /**
+     * Update a string in the language file
+     *
+     * @param string $key Key in dot notation
+     * @param string $translated Translated value
+     * @return void
+     */
+    public function updateString(string $key, string $translated): void
     {
-        $list = $this->flatten();
-        $list[$key] = $translated;
-        file_put_contents($this->filePath, "<?php" . PHP_EOL . "return " . var_export($list, true) . ";");
+        $this->loadOriginalContent();
+
+        if ($this->useDotNotation) {
+            $this->updateStringDotNotation($key, $translated);
+        } else {
+            $this->updateStringArrayNotation($key, $translated);
+        }
+
+        $this->flattenedContent = $this->flatten();
+    }
+
+    /**
+     * Update a string using dot notation (flat array)
+     *
+     * @param string $key Key in dot notation
+     * @param string $translated Translated value
+     * @return void
+     */
+    private function updateStringDotNotation(string $key, string $translated): void
+    {
+        $this->flattenedContent[$key] = $translated;
+
+        file_put_contents($this->filePath, "<?php" . PHP_EOL . "return " . var_export($this->flattenedContent, true) . ";");
+    }
+
+    /**
+     * Update a string while maintaining the nested array structure
+     *
+     * @param string $key Key in dot notation
+     * @param string $translated Translated value
+     * @return void
+     */
+    private function updateStringArrayNotation(string $key, string $translated): void
+    {
+        // Create a copy of the original content to work with
+        $content = $this->originalContent;
+
+        // Split the key by dots to navigate the nested array
+        $parts = explode('.', $key);
+
+        // Start with a reference to the content array
+        $current = &$content;
+
+        // Navigate through the nested array to find the right place
+        foreach ($parts as $i => $part) {
+            // If we're at the last part of the key, set the value
+            if ($i === count($parts) - 1) {
+                $current[$part] = $translated;
+            } else {
+                // Create the nested array if it doesn't exist
+                if (!isset($current[$part]) || !is_array($current[$part])) {
+                    $current[$part] = [];
+                }
+                // Move deeper into the nested array
+                $current = &$current[$part];
+            }
+        }
+
+        // Save the updated content back to the file
+        $this->saveContentToFile($content);
+
+        // Update the original content
+        $this->originalContent = $content;
+    }
+
+    /**
+     * Save content to file with proper formatting
+     *
+     * @param array $content Content to save
+     * @return void
+     */
+    private function saveContentToFile(array $content): void
+    {
+        $code = "<?php\n\nreturn " . $this->arrayExport($content, 0) . ";\n";
+        file_put_contents($this->filePath, $code);
+    }
+
+    /**
+     * Export array with proper indentation and formatting
+     *
+     * @param array $array Array to export
+     * @param int $level Indentation level
+     * @return string
+     */
+    private function arrayExport(array $array, int $level): string
+    {
+        $indent = str_repeat('    ', $level);
+        $output = "[\n";
+
+        $items = [];
+        foreach ($array as $key => $value) {
+            $formattedKey = is_int($key) ? $key : "'" . str_replace("'", "\\'", $key) . "'";
+
+            if (is_array($value)) {
+                $items[] = $indent . "    " . $formattedKey . " => " . $this->arrayExport($value, $level + 1);
+            } else {
+                $formattedValue = "'" . str_replace("'", "\\'", $value) . "'";
+                $items[] = $indent . "    " . $formattedKey . " => " . $formattedValue;
+            }
+        }
+
+        $output .= implode(",\n", $items);
+        $output .= "\n" . $indent . "]";
+
+        return $output;
     }
 }


### PR DESCRIPTION
Add CLI options and force flag to translator command

- Add direct command-line arguments for all interactive parameters
- Add --force flag to skip expensive translation confirmation
- Add non-interactive mode for automated environments
- Convert Korean comments to English for better maintainability

Example usage: `ai-translator:translate --source=en --reference=pl --chunk=25 --force --max-context=100`