### PR TITLE
Made prompt TXT files configurable

### DIFF
--- a/config/ai-translator.php
+++ b/config/ai-translator.php
@@ -30,8 +30,8 @@ return [
         // 'use_extended_thinking' => false, // Extended Thinking 기능 사용 여부 (claude-3-7-sonnet-latest 모델만 지원)
         // 'disable_stream' => true, // Disable streaming mode for better error messages
 
-        'prompt_system_file' => null,
-        'prompt_user_file' => null,
+        'prompt_system_file' => null, // Full path to prompt-system.txt - i.e. config_path('prompt-system.txt')
+        'prompt_user_file' => null, // Full path to prompt-user.txt - i.e. config_path('prompt-user.txt')
     ],
 
     // 'disable_plural' => true,

--- a/config/ai-translator.php
+++ b/config/ai-translator.php
@@ -29,6 +29,9 @@ return [
         // 'max_tokens' => 4096,
         // 'use_extended_thinking' => false, // Extended Thinking 기능 사용 여부 (claude-3-7-sonnet-latest 모델만 지원)
         // 'disable_stream' => true, // Disable streaming mode for better error messages
+
+        'prompt_system_file' => null,
+        'prompt_user_file' => null,
     ],
 
     // 'disable_plural' => true,

--- a/config/ai-translator.php
+++ b/config/ai-translator.php
@@ -30,13 +30,13 @@ return [
         // 'use_extended_thinking' => false, // Extended Thinking 기능 사용 여부 (claude-3-7-sonnet-latest 모델만 지원)
         // 'disable_stream' => true, // Disable streaming mode for better error messages
 
-        'prompt_system_file' => null, // Full path to prompt-system.txt - i.e. config_path('prompt-system.txt')
-        'prompt_user_file' => null, // Full path to prompt-user.txt - i.e. config_path('prompt-user.txt')
+        'prompt_custom_system_file_path' => null, // Full path to your own custom prompt-system.txt - i.e. resource_path('prompt-system.txt')
+        'prompt_custom_user_file_path' => null, // Full path to your own custom prompt-user.txt - i.e. resource_path('prompt-user.txt')
     ],
 
     // 'disable_plural' => true,
     // 'skip_locales' => [],
-    
+
     // If set to true, translations will be saved as flat arrays using dot notation keys. If set to false, translations will be saved as multi-dimensional arrays.
     'dot_notation' => true,
 

--- a/src/AI/AIProvider.php
+++ b/src/AI/AIProvider.php
@@ -148,7 +148,7 @@ class AIProvider
 
     protected function getSystemPrompt($replaces = [])
     {
-        $systemPrompt = file_get_contents(config('ai-translator.ai.prompt_system_file') ?? __DIR__ . '/prompt-system.txt');
+        $systemPrompt = file_get_contents(config('ai-translator.ai.prompt_custom_system_file_path') ?? __DIR__ . '/prompt-system.txt');
 
         $translationContext = '';
 
@@ -219,7 +219,7 @@ class AIProvider
 
     protected function getUserPrompt($replaces = [])
     {
-        $userPrompt = file_get_contents(config('ai-translator.ai.prompt_user_file') ?? __DIR__ . '/prompt-user.txt');
+        $userPrompt = file_get_contents(config('ai-translator.ai.prompt_custom_user_file_path') ?? __DIR__ . '/prompt-user.txt');
 
         $replaces = array_merge($replaces, [
             // Options
@@ -590,7 +590,7 @@ class AIProvider
                         if ($currentItemCount > $previousItemCount) {
                             $newItems = array_slice($currentItems, $previousItemCount);
                             $translatedItems = $currentItems; // 전체 번역 결과 업데이트
-
+    
                             // 새 번역 항목 각각에 대해 콜백 호출
                             foreach ($newItems as $index => $newItem) {
                                 // Skip already processed keys

--- a/src/AI/AIProvider.php
+++ b/src/AI/AIProvider.php
@@ -148,7 +148,7 @@ class AIProvider
 
     protected function getSystemPrompt($replaces = [])
     {
-        $systemPrompt = file_get_contents(__DIR__ . '/prompt-system.txt');
+        $systemPrompt = file_get_contents(config('ai-translator.ai.prompt_system_file') ?? __DIR__ . '/prompt-system.txt');
 
         $translationContext = '';
 
@@ -219,7 +219,7 @@ class AIProvider
 
     protected function getUserPrompt($replaces = [])
     {
-        $userPrompt = file_get_contents(__DIR__ . '/prompt-user.txt');
+        $userPrompt = file_get_contents(config('ai-translator.ai.prompt_user_file') ?? __DIR__ . '/prompt-user.txt');
 
         $replaces = array_merge($replaces, [
             // Options


### PR DESCRIPTION
Added 2 keys to config.php to configure paths of "prompt-system.txt" and "prompt-user.txt" which allows the usage of custom prompt files.