### PR TITLE
Fixed references locales

### DIFF
--- a/src/Console/TranslateStrings.php
+++ b/src/Console/TranslateStrings.php
@@ -129,7 +129,7 @@ class TranslateStrings extends Command
                     $this->colors['reset']);
             }
         } else if ($this->option('reference')) {
-            $this->referenceLocales = $this->option('reference');
+            $this->referenceLocales = explode(',', $this->option('reference'));
             $this->info($this->colors['green'] . "✓ Selected reference locales: " .
                 $this->colors['reset'] . $this->colors['bold'] . implode(', ', $this->referenceLocales) .
                 $this->colors['reset']);


### PR DESCRIPTION
Fixed error:

`Cannot assign string to property Kargnas\LaravelAiTranslator\Console\TranslateStrings::$referenceLocales of type array`