### PR TITLE
Add parallel translation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ To translate your language files, run the following command:
 php artisan ai-translator:translate
 ```
 
+To speed up translating multiple locales, you can run them in parallel. The command uses up to five processes by default:
+
+```bash
+php artisan ai-translator:translate-parallel --max-processes=5
+```
+
+Specify target locales separated by commas using the `--locale` option. For example:
+
+```bash
+php artisan ai-translator:translate-parallel --locale=ko,ja
+```
+
 This command will:
 
 1. Recognize all language folders in your `lang` directory

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "guzzlehttp/guzzle": "^7.0.1",
         "guzzlehttp/promises": "^2.0",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "openai-php/client": "^0.10.3"
+        "openai-php/client": "^0.10.3",
+        "symfony/process": "^6.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/src/Console/TranslateStringsParallel.php
+++ b/src/Console/TranslateStringsParallel.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Kargnas\LaravelAiTranslator\Console;
+
+use Symfony\Component\Process\Process;
+
+class TranslateStringsParallel extends TranslateStrings
+{
+    protected $signature = 'ai-translator:translate-parallel
+        {--s|source= : Source language to translate from (e.g. --source=en)}
+        {--l|locale=* : Target locales to translate (e.g. --locale=ko,ja)}
+        {--r|reference= : Reference languages for translation guidance (e.g. --reference=fr,es)}
+        {--c|chunk= : Chunk size for translation (e.g. --chunk=100)}
+        {--m|max-context= : Maximum number of context items to include (e.g. --max-context=1000)}
+        {--force-big-files : Force translation of files with more than 500 strings}
+        {--show-prompt : Show the whole AI prompts during translation}
+        {--max-processes=5 : Number of locales to translate simultaneously}
+        {--non-interactive : Run in non-interactive mode, using default or provided values}';
+
+    protected $description = 'Translates PHP language files in parallel for multiple locales.';
+
+    public function translate(int $maxContextItems = 100): void
+    {
+        $specifiedLocales = $this->option('locale');
+        $nonInteractive = $this->option('non-interactive');
+        $availableLocales = $this->getExistingLocales();
+
+        if (!$nonInteractive && empty($specifiedLocales)) {
+            $selected = $this->choiceLanguages(
+                $this->colors['yellow'] . 'Choose target locales for translation. Multiple selections with comma separator (e.g. "1,2")' . $this->colors['reset'],
+                true
+            );
+            $locales = is_array($selected) ? $selected : [$selected];
+        } else {
+            $locales = !empty($specifiedLocales)
+                ? $this->validateAndFilterLocales($specifiedLocales, $availableLocales)
+                : $availableLocales;
+        }
+
+        if (empty($locales)) {
+            $this->error('No valid locales specified or found for translation.');
+            return;
+        }
+
+        $queue = [];
+        foreach ($locales as $locale) {
+            if ($locale === $this->sourceLocale || in_array($locale, config('ai-translator.skip_locales', []))) {
+                $this->warn('Skipping locale ' . $locale . '.');
+                continue;
+            }
+            $queue[] = $locale;
+        }
+
+        $maxProcesses = (int) ($this->option('max-processes') ?? 5);
+        $running = [];
+
+        while (!empty($queue) || !empty($running)) {
+            while (count($running) < $maxProcesses && !empty($queue)) {
+                $locale = array_shift($queue);
+                $process = new Process($this->buildLocaleCommand($locale, $maxContextItems), base_path());
+                $process->start();
+                $running[$locale] = $process;
+                $this->info('▶ Started translation for ' . $locale);
+            }
+
+            foreach ($running as $locale => $process) {
+                if (!$process->isRunning()) {
+                    $this->output->write($process->getOutput());
+                    $error = $process->getErrorOutput();
+                    if ($error) {
+                        $this->error($error);
+                    }
+                    unset($running[$locale]);
+                }
+            }
+
+            usleep(100000);
+        }
+
+        $this->line('\n' . $this->colors['green_bg'] . $this->colors['white'] . $this->colors['bold'] . ' All translations completed ' . $this->colors['reset']);
+    }
+
+    private function buildLocaleCommand(string $locale, int $maxContextItems): array
+    {
+        $cmd = [
+            'php',
+            'artisan',
+            'ai-translator:translate',
+            '--source=' . $this->sourceLocale,
+            '--locale=' . $locale,
+            '--chunk=' . $this->chunkSize,
+            '--max-context=' . $maxContextItems,
+            '--non-interactive',
+        ];
+
+        if (!empty($this->referenceLocales)) {
+            $cmd[] = '--reference=' . implode(',', $this->referenceLocales);
+        }
+        if ($this->option('force-big-files')) {
+            $cmd[] = '--force-big-files';
+        }
+        if ($this->option('show-prompt')) {
+            $cmd[] = '--show-prompt';
+        }
+
+        return $cmd;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,6 +6,7 @@ namespace Kargnas\LaravelAiTranslator;
 use Kargnas\LaravelAiTranslator\Console\TestTranslateCommand;
 use Kargnas\LaravelAiTranslator\Console\TranslateCrowdin;
 use Kargnas\LaravelAiTranslator\Console\TranslateStrings;
+use Kargnas\LaravelAiTranslator\Console\TranslateStringsParallel;
 use Kargnas\LaravelAiTranslator\Console\TranslateFileCommand;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
@@ -26,6 +27,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         $this->commands([
             TranslateStrings::class,
+            TranslateStringsParallel::class,
             TranslateCrowdin::class,
             TestTranslateCommand::class,
             TranslateFileCommand::class,


### PR DESCRIPTION
## Summary
- allow translating multiple locales at once via `translate-parallel`
- register the new command in the service provider
- require `symfony/process`
- document parallel translation usage
- set parallel process default to 5 and explain how to specify locales

## Testing
- `composer install` *(fails: command not found)*
- `php ./vendor/bin/pest` *(fails: command not found)*