### PR TITLE
Fix parallel command reference locales and default locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Specify target locales separated by commas using the `--locale` option. For exam
 php artisan ai-translator:translate-parallel --locale=ko,ja
 ```
 
+If you omit the `--locale` option, the command automatically translates all available locales.
+
 This command will:
 
 1. Recognize all language folders in your `lang` directory

--- a/src/Console/TranslateStrings.php
+++ b/src/Console/TranslateStrings.php
@@ -122,7 +122,9 @@ class TranslateStrings extends Command
 
         // Select reference languages
         if ($nonInteractive) {
-            $this->referenceLocales = $this->option('reference') ?? [];
+            $this->referenceLocales = $this->option('reference')
+                ? explode(',', (string) $this->option('reference'))
+                : [];
             if (!empty($this->referenceLocales)) {
                 $this->info($this->colors['green'] . "✓ Selected reference locales: " .
                     $this->colors['reset'] . $this->colors['bold'] . implode(', ', $this->referenceLocales) .
@@ -245,7 +247,7 @@ class TranslateStrings extends Command
         foreach ($locales as $locale) {
             // 소스 언어와 같거나 스킵 목록에 있는 언어는 건너뜀
            if ($locale === $this->sourceLocale || in_array($locale, config('ai-translator.skip_locales', []))) {
-                this->warn('Skipping locale ' . $locale .'.');
+                $this->warn('Skipping locale ' . $locale . '.');
                 continue;
             }
 

--- a/src/Console/TranslateStringsParallel.php
+++ b/src/Console/TranslateStringsParallel.php
@@ -26,11 +26,10 @@ class TranslateStringsParallel extends TranslateStrings
         $availableLocales = $this->getExistingLocales();
 
         if (!$nonInteractive && empty($specifiedLocales)) {
-            $selected = $this->choiceLanguages(
-                $this->colors['yellow'] . 'Choose target locales for translation. Multiple selections with comma separator (e.g. "1,2")' . $this->colors['reset'],
-                true
-            );
-            $locales = is_array($selected) ? $selected : [$selected];
+            $locales = $availableLocales;
+            $this->info($this->colors['green'] . '✓ Selected locales: ' .
+                $this->colors['reset'] . $this->colors['bold'] . implode(', ', $locales) .
+                $this->colors['reset']);
         } else {
             $locales = !empty($specifiedLocales)
                 ? $this->validateAndFilterLocales($specifiedLocales, $availableLocales)


### PR DESCRIPTION
## Summary
- parse reference locales properly when running in non-interactive mode
- fix locale skipping warning
- default to translating all locales when none are specified in the parallel command
- document new default behaviour

## Testing
- `git status --short`