### PR TITLE
Add PO command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Whether you're working on a personal project or a large-scale application, Larav
 
 - Automatically detects all language folders in your `lang` directory
 - Translates PHP language files from a source language (default: English) to all other languages
+- Supports gettext PO files via the `translate-po` command
 - Supports multiple AI providers for intelligent, context-aware translations
 - Preserves variables, HTML tags, pluralization codes, and nested structures
 - Maintains consistent tone and style across translations
@@ -452,7 +453,7 @@ Make sure to set your chosen AI provider's API key in your `.env` file.
 
 ## Supported File Types
 
-Currently, this package only supports PHP language files used by Laravel. JSON language files are not supported, and there are no plans to add support for them in the future.
+This package primarily works with PHP language files used by Laravel. JSON language files are not supported, and there are no plans to add support for them in the future. Gettext `.po` files can be translated using the dedicated `translate-po` command.
 
 ### Why PHP files only?
 

--- a/src/AI/PoTranslationContextProvider.php
+++ b/src/AI/PoTranslationContextProvider.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Kargnas\LaravelAiTranslator\AI;
+
+use Kargnas\LaravelAiTranslator\Transformers\PoLangTransformer;
+
+/**
+ * Provides translation context for PO files.
+ */
+class PoTranslationContextProvider
+{
+    public function getGlobalTranslationContext(
+        string $sourceLocale,
+        string $targetLocale,
+        string $currentFilePath,
+        int $maxContextItems = 100
+    ): array {
+        $langDirectory = config('ai-translator.source_directory');
+
+        $sourceLocaleDir = $this->getLanguageDirectory($langDirectory, $sourceLocale);
+        $targetLocaleDir = $this->getLanguageDirectory($langDirectory, $targetLocale);
+
+        if (!is_dir($sourceLocaleDir)) {
+            return [];
+        }
+
+        $currentFileName = basename($currentFilePath);
+        $context = [];
+        $totalContextItems = 0;
+
+        $sourceFiles = glob("{$sourceLocaleDir}/*.po");
+        if (empty($sourceFiles)) {
+            return [];
+        }
+
+        usort($sourceFiles, function ($a, $b) use ($currentFileName) {
+            $similarityA = similar_text($currentFileName, basename($a));
+            $similarityB = similar_text($currentFileName, basename($b));
+            return $similarityB <=> $similarityA;
+        });
+
+        foreach ($sourceFiles as $sourceFile) {
+            if ($totalContextItems >= $maxContextItems) {
+                break;
+            }
+
+            try {
+                $targetFile = $targetLocaleDir . '/' . basename($sourceFile);
+                $hasTargetFile = file_exists($targetFile);
+
+                $sourceTransformer = new PoLangTransformer($sourceFile);
+                $sourceStrings = $sourceTransformer->flatten();
+                if (empty($sourceStrings)) {
+                    continue;
+                }
+
+                $targetStrings = [];
+                if ($hasTargetFile) {
+                    $targetTransformer = new PoLangTransformer($targetFile);
+                    $targetStrings = $targetTransformer->flatten();
+                }
+
+                $maxPerFile = min(20, intval($maxContextItems / count($sourceFiles) / 2) + 1);
+
+                if (count($sourceStrings) > $maxPerFile) {
+                    if ($hasTargetFile && !empty($targetStrings)) {
+                        $prioritizedItems = $this->getPrioritizedStrings($sourceStrings, $targetStrings, $maxPerFile);
+                        $sourceStrings = $prioritizedItems['source'];
+                        $targetStrings = $prioritizedItems['target'];
+                    } else {
+                        $sourceStrings = $this->getPrioritizedSourceOnly($sourceStrings, $maxPerFile);
+                    }
+                }
+
+                $fileContext = [];
+                foreach ($sourceStrings as $key => $sourceValue) {
+                    if ($hasTargetFile && !empty($targetStrings)) {
+                        $targetValue = $targetStrings[$key] ?? null;
+                        if ($targetValue !== null) {
+                            $fileContext[$key] = [
+                                'source' => $sourceValue,
+                                'target' => $targetValue,
+                            ];
+                        }
+                    } else {
+                        $fileContext[$key] = [
+                            'source' => $sourceValue,
+                            'target' => null,
+                        ];
+                    }
+                }
+
+                if (!empty($fileContext)) {
+                    $rootKey = pathinfo(basename($sourceFile), PATHINFO_FILENAME);
+                    $context[$rootKey] = $fileContext;
+                    $totalContextItems += count($fileContext);
+                }
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
+
+        return $context;
+    }
+
+    protected function getLanguageDirectory(string $langDirectory, string $locale): string
+    {
+        $langDirectory = rtrim($langDirectory, '/');
+        if (preg_match('#/[a-z]{2}(_[A-Z]{2})?$#', $langDirectory)) {
+            return preg_replace('#/[a-z]{2}(_[A-Z]{2})?$#', "/{$locale}", $langDirectory);
+        }
+        return "{$langDirectory}/{$locale}";
+    }
+
+    protected function getPrioritizedStrings(array $sourceStrings, array $targetStrings, int $maxItems): array
+    {
+        $prioritizedSource = [];
+        $prioritizedTarget = [];
+        $commonKeys = array_intersect(array_keys($sourceStrings), array_keys($targetStrings));
+
+        foreach ($commonKeys as $key) {
+            if (strlen($sourceStrings[$key]) < 50 && count($prioritizedSource) < $maxItems * 0.7) {
+                $prioritizedSource[$key] = $sourceStrings[$key];
+                $prioritizedTarget[$key] = $targetStrings[$key];
+            }
+        }
+
+        foreach ($commonKeys as $key) {
+            if (!isset($prioritizedSource[$key]) && count($prioritizedSource) < $maxItems) {
+                $prioritizedSource[$key] = $sourceStrings[$key];
+                $prioritizedTarget[$key] = $targetStrings[$key];
+            }
+            if (count($prioritizedSource) >= $maxItems) {
+                break;
+            }
+        }
+
+        return [
+            'source' => $prioritizedSource,
+            'target' => $prioritizedTarget,
+        ];
+    }
+
+    protected function getPrioritizedSourceOnly(array $sourceStrings, int $maxItems): array
+    {
+        $prioritizedSource = [];
+        foreach ($sourceStrings as $key => $value) {
+            if (strlen($value) < 50 && count($prioritizedSource) < $maxItems * 0.7) {
+                $prioritizedSource[$key] = $value;
+            }
+        }
+        foreach ($sourceStrings as $key => $value) {
+            if (!isset($prioritizedSource[$key]) && count($prioritizedSource) < $maxItems) {
+                $prioritizedSource[$key] = $value;
+            }
+            if (count($prioritizedSource) >= $maxItems) {
+                break;
+            }
+        }
+        return $prioritizedSource;
+    }
+}

--- a/src/Console/TranslatePoFileCommand.php
+++ b/src/Console/TranslatePoFileCommand.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Kargnas\LaravelAiTranslator\Console;
+
+use Illuminate\Console\Command;
+use Kargnas\LaravelAiTranslator\AI\AIProvider;
+use Kargnas\LaravelAiTranslator\AI\PoTranslationContextProvider;
+use Kargnas\LaravelAiTranslator\AI\Language\Language;
+use Kargnas\LaravelAiTranslator\AI\Printer\TokenUsagePrinter;
+use Kargnas\LaravelAiTranslator\Enums\TranslationStatus;
+use Kargnas\LaravelAiTranslator\Models\LocalizedString;
+use Kargnas\LaravelAiTranslator\Transformers\PoLangTransformer;
+
+class TranslatePoFileCommand extends Command
+{
+    protected $signature = 'ai-translator:translate-po-file'
+        . ' {file : Path to the PO file to translate}'
+        . ' {--source-language=en : Source language code (ex: en)}'
+        . ' {--target-language=ko : Target language code (ex: ko)}'
+        . ' {--rules=* : Additional rules}'
+        . ' {--debug : Enable debug mode}'
+        . ' {--show-ai-response : Show raw AI response during translation}'
+        . ' {--max-context-items=100 : Maximum number of context items}';
+
+    protected $description = 'Translate a specific PO file with an array of strings';
+
+    private $thinkingBlockCount = 0;
+
+    protected $colors = [
+        'gray' => "\033[38;5;245m",
+        'blue' => "\033[38;5;33m",
+        'green' => "\033[38;5;40m",
+        'yellow' => "\033[38;5;220m",
+        'purple' => "\033[38;5;141m",
+        'red' => "\033[38;5;196m",
+        'reset' => "\033[0m",
+        'blue_bg' => "\033[48;5;24m",
+        'white' => "\033[38;5;255m",
+        'bold' => "\033[1m",
+        'yellow_bg' => "\033[48;5;220m",
+        'black' => "\033[38;5;16m",
+        'line_clear' => "\033[2K\r",
+    ];
+
+    public function handle()
+    {
+        $GLOBALS['instant_results'] = [];
+
+        $filePath = $this->argument('file');
+        $sourceLanguage = $this->option('source-language');
+        $targetLanguage = $this->option('target-language');
+        $rules = $this->option('rules') ?: [];
+        $showAiResponse = $this->option('show-ai-response');
+        $debug = $this->option('debug');
+
+        if ($debug) {
+            config(['app.debug' => true]);
+            config(['ai-translator.debug' => true]);
+        }
+
+        if (!file_exists($filePath) || pathinfo($filePath, PATHINFO_EXTENSION) !== 'po') {
+            $this->error("PO file not found: {$filePath}");
+            return 1;
+        }
+
+        $transformer = new PoLangTransformer($filePath, $sourceLanguage);
+        $strings = $transformer->flatten();
+
+        $this->info("Starting translation of file: {$filePath}");
+        $this->info("Source language: {$sourceLanguage}");
+        $this->info("Target language: {$targetLanguage}");
+        $this->info('Total strings: ' . count($strings));
+
+        config(['ai-translator.ai.model' => 'claude-3-7-sonnet-latest']);
+        config(['ai-translator.ai.max_tokens' => 64000]);
+        config(['ai-translator.ai.use_extended_thinking' => false]);
+        config(['ai-translator.ai.disable_stream' => false]);
+
+        $contextProvider = new PoTranslationContextProvider();
+        $maxContextItems = (int) $this->option('max-context-items') ?: 100;
+        $globalContext = $contextProvider->getGlobalTranslationContext(
+            $sourceLanguage,
+            $targetLanguage,
+            $filePath,
+            $maxContextItems
+        );
+
+        $this->line($this->colors['blue_bg'] . $this->colors['white'] . $this->colors['bold'] . ' Translation Context ' . $this->colors['reset']);
+        $this->line(' - Context files: ' . count($globalContext));
+        $this->line(' - Total context items: ' . collect($globalContext)->map(fn($items) => count($items))->sum());
+
+        $provider = new AIProvider(
+            basename($filePath),
+            $strings,
+            $sourceLanguage,
+            $targetLanguage,
+            [],
+            $rules,
+            $globalContext
+        );
+
+        $this->line("\n" . str_repeat('─', 80));
+        $this->line($this->colors['blue_bg'] . $this->colors['white'] . $this->colors['bold'] . ' Translation Configuration ' . $this->colors['reset']);
+
+        $this->line($this->colors['yellow'] . 'Source' . $this->colors['reset'] . ': '
+            . $this->colors['green'] . $provider->sourceLanguageObj->name
+            . $this->colors['gray'] . ' (' . $provider->sourceLanguageObj->code . ')' . $this->colors['reset']);
+
+        $this->line($this->colors['yellow'] . 'Target' . $this->colors['reset'] . ': '
+            . $this->colors['green'] . $provider->targetLanguageObj->name
+            . $this->colors['gray'] . ' (' . $provider->targetLanguageObj->code . ')' . $this->colors['reset']);
+
+        $this->line($this->colors['yellow'] . 'Rules' . $this->colors['reset'] . ': '
+            . $this->colors['purple'] . count($provider->additionalRules) . ' rules' . $this->colors['reset']);
+
+        if (!empty($provider->additionalRules)) {
+            $this->line($this->colors['gray'] . 'Rule Preview:' . $this->colors['reset']);
+            foreach (array_slice($provider->additionalRules, 0, 3) as $index => $rule) {
+                $shortRule = strlen($rule) > 100 ? substr($rule, 0, 97) . '...' : $rule;
+                $this->line($this->colors['blue'] . ' ' . ($index + 1) . '.' . $this->colors['reset'] . $shortRule);
+            }
+            if (count($provider->additionalRules) > 3) {
+                $this->line($this->colors['gray'] . ' ... and '
+                    . (count($provider->additionalRules) - 3) . ' more rules' . $this->colors['reset']);
+            }
+        }
+
+        $this->line(str_repeat('─', 80) . "\n");
+
+        $totalItems = count($strings);
+        $results = [];
+
+        $onTokenUsage = function (array $usage) use ($provider) {
+            $this->updateTokenUsageDisplay($usage);
+            if (($usage['final'] ?? false)) {
+                $printer = new TokenUsagePrinter($provider->getModel());
+                $printer->printFullReport($this, $usage);
+            }
+        };
+
+        $onTranslated = function (LocalizedString $item, string $status, array $translatedItems) use ($strings, $totalItems) {
+            $originalText = $strings[$item->key] ?? '';
+            switch ($status) {
+                case TranslationStatus::STARTED:
+                    $this->line("\n" . str_repeat('─', 80));
+                    $this->line($this->colors['blue_bg'] . $this->colors['white'] . $this->colors['bold']
+                        . ' Translation Started ' . count($translatedItems) . "/{$totalItems} " . $this->colors['reset'] . ' '
+                        . $this->colors['yellow_bg'] . $this->colors['black'] . $this->colors['bold'] . " {$item->key} " . $this->colors['reset']);
+                    $this->line($this->colors['gray'] . 'Source:' . $this->colors['reset'] . ' ' . substr($originalText, 0, 100)
+                        . (strlen($originalText) > 100 ? '...' : ''));
+                    break;
+                case TranslationStatus::COMPLETED:
+                    $this->line($this->colors['green'] . $this->colors['bold'] . 'Translation:' . $this->colors['reset'] . ' '
+                        . $this->colors['bold'] . substr($item->translated, 0, 100)
+                        . (strlen($item->translated) > 100 ? '...' : '') . $this->colors['reset']);
+                    if ($item->comment) {
+                        $this->line($this->colors['gray'] . 'Comment:' . $this->colors['reset'] . ' ' . $item->comment);
+                    }
+                    break;
+            }
+        };
+
+        $onProgress = function ($currentText) use ($showAiResponse) {
+            if ($showAiResponse) {
+                $responsePreview = preg_replace('/[\n\r]+/', ' ', substr($currentText, -100));
+                $this->line($this->colors['line_clear'] . $this->colors['purple'] . 'AI Response:' . $this->colors['reset'] . ' ' . $responsePreview);
+            }
+        };
+
+        $onThinking = function ($delta) {
+            echo $this->colors['gray'] . $delta . $this->colors['reset'];
+        };
+        $onThinkingStart = function () {
+            $this->thinkingBlockCount++;
+            $this->line('');
+            $this->line($this->colors['purple'] . '🧠 AI Thinking Block #' . $this->thinkingBlockCount . ' Started...' . $this->colors['reset']);
+        };
+        $onThinkingEnd = function ($completeThinkingContent) {
+            $this->line('');
+            $this->line($this->colors['purple'] . '✓ Thinking completed (' . strlen($completeThinkingContent) . ' chars)' . $this->colors['reset']);
+            $this->line('');
+        };
+
+        $translatedItems = $provider
+            ->setOnTranslated($onTranslated)
+            ->setOnThinking($onThinking)
+            ->setOnProgress($onProgress)
+            ->setOnThinkingStart($onThinkingStart)
+            ->setOnThinkingEnd($onThinkingEnd)
+            ->setOnTokenUsage($onTokenUsage)
+            ->translate();
+
+        foreach ($translatedItems as $item) {
+            $results[$item->key] = $item->translated;
+        }
+
+        $outputFilePath = pathinfo($filePath, PATHINFO_DIRNAME) . '/'
+            . pathinfo($filePath, PATHINFO_FILENAME) . '-' . $targetLanguage . '.po';
+
+        $outputTransformer = new PoLangTransformer($outputFilePath, $sourceLanguage);
+        foreach ($results as $k => $v) {
+            $outputTransformer->updateString($k, $v);
+        }
+
+        $this->info("\nTranslation completed. Output written to: {$outputFilePath}");
+
+        return 0;
+    }
+
+    protected function updateTokenUsageDisplay(array $usage): void
+    {
+        if (($usage['input_tokens'] ?? 0) == 0 && ($usage['output_tokens'] ?? 0) == 0) {
+            return;
+        }
+
+        $this->output->write("\033[2K\r");
+        $this->output->write(
+            $this->colors['purple'] . 'Tokens: '
+            . $this->colors['reset'] . 'Input: ' . $this->colors['green'] . ($usage['input_tokens'] ?? 0)
+            . $this->colors['reset'] . ' | Output: ' . $this->colors['green'] . ($usage['output_tokens'] ?? 0)
+            . $this->colors['reset'] . ' | Cache created: ' . $this->colors['blue'] . ($usage['cache_creation_input_tokens'] ?? 0)
+            . $this->colors['reset'] . ' | Cache read: ' . $this->colors['blue'] . ($usage['cache_read_input_tokens'] ?? 0)
+            . $this->colors['reset'] . ' | Total: ' . $this->colors['yellow'] . ($usage['total_tokens'] ?? 0)
+            . $this->colors['reset']
+        );
+    }
+}

--- a/src/Console/TranslatePoStrings.php
+++ b/src/Console/TranslatePoStrings.php
@@ -1,0 +1,742 @@
+<?php
+
+namespace Kargnas\LaravelAiTranslator\Console;
+
+use Illuminate\Console\Command;
+use Kargnas\LaravelAiTranslator\AI\AIProvider;
+use Kargnas\LaravelAiTranslator\AI\Language\LanguageConfig;
+use Kargnas\LaravelAiTranslator\AI\Printer\TokenUsagePrinter;
+use Kargnas\LaravelAiTranslator\AI\PoTranslationContextProvider;
+use Kargnas\LaravelAiTranslator\Enums\TranslationStatus;
+use Kargnas\LaravelAiTranslator\Transformers\PoLangTransformer;
+use Kargnas\LaravelAiTranslator\Utility;
+use Kargnas\LaravelAiTranslator\Enums\PromptType;
+
+/**
+ * Artisan command that translates gettext PO language files using LLMs with support for multiple locales,
+ * reference languages, chunking for large files, and customizable context settings
+ */
+class TranslatePoStrings extends Command
+{
+    protected $signature = 'ai-translator:translate-po
+        {--s|source= : Source language to translate from (e.g. --source=en)}
+        {--l|locale=* : Target locales to translate (e.g. --locale=ko,ja). If not provided, will ask interactively}
+        {--r|reference= : Reference languages for translation guidance (e.g. --reference=fr,es). If not provided, will ask interactively}
+        {--c|chunk= : Chunk size for translation (e.g. --chunk=100)}
+        {--m|max-context= : Maximum number of context items to include (e.g. --max-context=1000)}
+        {--force-big-files : Force translation of files with more than 500 strings}
+        {--show-prompt : Show the whole AI prompts during translation}
+        {--non-interactive : Run in non-interactive mode, using default or provided values}';
+
+    protected $description = 'Translates gettext PO language files using LLMs with support for multiple locales, reference languages, chunking for large files, and customizable context settings';
+
+    /**
+     * Translation settings
+     */
+    protected string $sourceLocale;
+    protected string $sourceDirectory;
+    protected int $chunkSize;
+    protected array $referenceLocales = [];
+
+    protected int $defaultChunkSize = 100;
+    protected int $defaultMaxContextItems = 1000;
+    protected int $warningStringCount = 500;
+
+    /**
+     * Token usage tracking
+     */
+    protected array $tokenUsage = [
+        'input_tokens' => 0,
+        'output_tokens' => 0,
+        'total_tokens' => 0
+    ];
+
+    /**
+     * Color codes
+     */
+    protected array $colors = [
+        'reset' => "\033[0m",
+        'red' => "\033[31m",
+        'green' => "\033[32m",
+        'yellow' => "\033[33m",
+        'blue' => "\033[34m",
+        'purple' => "\033[35m",
+        'cyan' => "\033[36m",
+        'white' => "\033[37m",
+        'gray' => "\033[90m",
+        'bold' => "\033[1m",
+        'underline' => "\033[4m",
+        'red_bg' => "\033[41m",
+        'green_bg' => "\033[42m",
+        'yellow_bg' => "\033[43m",
+        'blue_bg' => "\033[44m",
+        'purple_bg' => "\033[45m",
+        'cyan_bg' => "\033[46m",
+        'white_bg' => "\033[47m"
+    ];
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $sourceDirectory = config('ai-translator.source_directory');
+        $sourceLocale = config('ai-translator.source_locale');
+
+        $this->setDescription(
+            "Translates gettext PO language files using AI technology\n" .
+            "  Source Directory: {$sourceDirectory}\n" .
+            "  Default Source Locale: {$sourceLocale}"
+        );
+    }
+
+    /**
+     * Main command execution method
+     */
+    public function handle()
+    {
+        // Display header
+        $this->displayHeader();
+
+        // Set source directory
+        $this->sourceDirectory = config('ai-translator.source_directory');
+
+        // Check if running in non-interactive mode
+        $nonInteractive = $this->option('non-interactive');
+
+        // Select source language
+        if ($nonInteractive || $this->option('source')) {
+            $this->sourceLocale = $this->option('source') ?? config('ai-translator.source_locale', 'en');
+            $this->info($this->colors['green'] . "✓ Selected source locale: " .
+                $this->colors['reset'] . $this->colors['bold'] . $this->sourceLocale .
+                $this->colors['reset']);
+        } else {
+            $this->sourceLocale = $this->choiceLanguages(
+                $this->colors['yellow'] . "Choose a source language to translate from" . $this->colors['reset'],
+                false,
+                'en'
+            );
+        }
+
+        // Select reference languages
+        if ($nonInteractive) {
+            $this->referenceLocales = $this->option('reference')
+                ? explode(',', (string) $this->option('reference'))
+                : [];
+            if (!empty($this->referenceLocales)) {
+                $this->info($this->colors['green'] . "✓ Selected reference locales: " .
+                    $this->colors['reset'] . $this->colors['bold'] . implode(', ', $this->referenceLocales) .
+                    $this->colors['reset']);
+            }
+        } else if ($this->option('reference')) {
+            $this->referenceLocales = explode(',', $this->option('reference'));
+            $this->info($this->colors['green'] . "✓ Selected reference locales: " .
+                $this->colors['reset'] . $this->colors['bold'] . implode(', ', $this->referenceLocales) .
+                $this->colors['reset']);
+        } else if ($this->ask($this->colors['yellow'] . 'Do you want to add reference languages? (y/n)' . $this->colors['reset'], 'n') === 'y') {
+            $this->referenceLocales = $this->choiceLanguages(
+                $this->colors['yellow'] . "Choose reference languages for translation guidance. Select languages with high-quality translations. Multiple selections with comma separator (e.g. '1,2')" . $this->colors['reset'],
+                true
+            );
+        }
+
+        // Set chunk size
+        if ($nonInteractive || $this->option('chunk')) {
+            $this->chunkSize = (int) ($this->option('chunk') ?? $this->defaultChunkSize);
+            $this->info($this->colors['green'] . "✓ Chunk size: " .
+                $this->colors['reset'] . $this->colors['bold'] . $this->chunkSize .
+                $this->colors['reset']);
+        } else {
+            $this->chunkSize = (int) $this->ask(
+                $this->colors['yellow'] . "Enter the chunk size for translation. Translate strings in a batch. The higher, the cheaper." . $this->colors['reset'],
+                $this->defaultChunkSize
+            );
+        }
+
+        // Set context items count
+        if ($nonInteractive || $this->option('max-context')) {
+            $maxContextItems = (int) ($this->option('max-context') ?? $this->defaultMaxContextItems);
+            $this->info($this->colors['green'] . "✓ Maximum context items: " .
+                $this->colors['reset'] . $this->colors['bold'] . $maxContextItems .
+                $this->colors['reset']);
+        } else {
+            $maxContextItems = (int) $this->ask(
+                $this->colors['yellow'] . "Maximum number of context items to include for consistency (set 0 to disable)" . $this->colors['reset'],
+                $this->defaultMaxContextItems
+            );
+        }
+
+        // Execute translation
+        $this->translate($maxContextItems);
+
+        return 0;
+    }
+
+    /**
+     * 헤더 출력
+     */
+    protected function displayHeader(): void
+    {
+        $this->line("\n" . $this->colors['blue_bg'] . $this->colors['white'] . $this->colors['bold'] . " Laravel AI Translator " . $this->colors['reset']);
+        $this->line($this->colors['gray'] . "Translating gettext PO language files using AI technology" . $this->colors['reset']);
+        $this->line(str_repeat('─', 80) . "\n");
+    }
+
+    /**
+     * 언어 선택 헬퍼 메서드
+     *
+     * @param string $question 질문
+     * @param bool $multiple 다중 선택 여부
+     * @param string|null $default 기본값
+     * @return array|string 선택된 언어(들)
+     */
+    public function choiceLanguages(string $question, bool $multiple, ?string $default = null): array|string
+    {
+        $locales = $this->getExistingLocales();
+
+        $selectedLocales = $this->choice(
+            $question,
+            $locales,
+            $default,
+            3,
+            $multiple
+        );
+
+        if (is_array($selectedLocales)) {
+            $this->info($this->colors['green'] . "✓ Selected locales: " .
+                $this->colors['reset'] . $this->colors['bold'] . implode(', ', $selectedLocales) .
+                $this->colors['reset']);
+        } else {
+            $this->info($this->colors['green'] . "✓ Selected locale: " .
+                $this->colors['reset'] . $this->colors['bold'] . $selectedLocales .
+                $this->colors['reset']);
+        }
+
+        return $selectedLocales;
+    }
+
+    /**
+     * 번역 실행
+     *
+     * @param int $maxContextItems 최대 컨텍스트 항목 수
+     */
+    public function translate(int $maxContextItems = 100): void
+    {
+        // 커맨드라인에서 지정된 로케일 가져오기
+        $specifiedLocales = $this->option('locale');
+
+        // 사용 가능한 모든 로케일 가져오기
+        $availableLocales = $this->getExistingLocales();
+
+        // 지정된 로케일이 있으면 검증하고 사용, 없으면 모든 로케일 사용
+        $locales = !empty($specifiedLocales)
+            ? $this->validateAndFilterLocales($specifiedLocales, $availableLocales)
+            : $availableLocales;
+
+        if (empty($locales)) {
+            $this->error("No valid locales specified or found for translation.");
+            return;
+        }
+
+        $fileCount = 0;
+        $totalStringCount = 0;
+        $totalTranslatedCount = 0;
+
+        foreach ($locales as $locale) {
+            // 소스 언어와 같거나 스킵 목록에 있는 언어는 건너뜀
+            if ($locale === $this->sourceLocale || in_array($locale, config('ai-translator.skip_locales', []))) {
+                $this->warn('Skipping locale ' . $locale . '.');
+                continue;
+            }
+
+            $targetLanguageName = LanguageConfig::getLanguageName($locale);
+
+            if (!$targetLanguageName) {
+                $this->error("Language name not found for locale: {$locale}. Please add it to the config file.");
+                continue;
+            }
+
+            $this->line(str_repeat('─', 80));
+            $this->line(str_repeat('─', 80));
+            $this->line("\n" . $this->colors['blue_bg'] . $this->colors['white'] . $this->colors['bold'] . " Starting {$targetLanguageName} ({$locale}) " . $this->colors['reset']);
+
+            $localeFileCount = 0;
+            $localeStringCount = 0;
+            $localeTranslatedCount = 0;
+
+            // 소스 파일 목록 가져오기
+            $files = $this->getStringFilePaths($this->sourceLocale);
+
+            foreach ($files as $file) {
+                $outputFile = $this->getOutputDirectoryLocale($locale) . '/' . basename($file);
+
+                if (in_array(basename($file), config('ai-translator.skip_files', []))) {
+                    $this->warn('Skipping file  ' . basename($file) . '.');
+                    continue;
+                }
+
+                $this->displayFileInfo($file, $locale, $outputFile);
+
+                $localeFileCount++;
+                $fileCount++;
+
+                // Load source strings
+                $transformer = $this->createTransformer($file);
+                $sourceStringList = $transformer->flatten();
+
+                // Load target strings (or create)
+                $targetStringTransformer = $this->createTransformer($outputFile);
+
+                // Filter untranslated strings only
+                $sourceStringList = collect($sourceStringList)
+                    ->filter(function ($value, $key) use ($targetStringTransformer) {
+                        // Skip already translated ones
+                        return !$targetStringTransformer->isTranslated($key);
+                    })
+                    ->toArray();
+
+                // Skip if no items to translate
+                if (count($sourceStringList) === 0) {
+                    $this->info($this->colors['green'] . "  ✓ " . $this->colors['reset'] . "All strings are already translated. Skipping.");
+                    continue;
+                }
+
+                $localeStringCount += count($sourceStringList);
+                $totalStringCount += count($sourceStringList);
+
+                // Check if there are many strings to translate
+                if (count($sourceStringList) > $this->warningStringCount && !$this->option('force-big-files')) {
+                    if (
+                        !$this->confirm(
+                            $this->colors['yellow'] . "⚠️ Warning: " . $this->colors['reset'] .
+                            "File has " . count($sourceStringList) . " strings to translate. This could be expensive. Continue?",
+                            true
+                        )
+                    ) {
+                        $this->warn("Translation stopped by user.");
+                        return;
+                    }
+                }
+
+                // Load reference translations (from all files)
+                $referenceStringList = $this->loadReferenceTranslations($file, $locale, $sourceStringList);
+
+                // Process in chunks
+                $chunkCount = 0;
+                $totalChunks = ceil(count($sourceStringList) / $this->chunkSize);
+
+                collect($sourceStringList)
+                    ->chunk($this->chunkSize)
+                    ->each(function ($chunk) use ($locale, $file, $targetStringTransformer, $referenceStringList, $maxContextItems, &$localeTranslatedCount, &$totalTranslatedCount, &$chunkCount, $totalChunks) {
+                        $chunkCount++;
+                        $this->info($this->colors['yellow'] . "  ⏺ Processing chunk " .
+                            $this->colors['reset'] . "{$chunkCount}/{$totalChunks}" .
+                            $this->colors['gray'] . " (" . $chunk->count() . " strings)" .
+                            $this->colors['reset']);
+
+                        // Get global translation context
+                        $globalContext = $this->getGlobalContext($file, $locale, $maxContextItems);
+
+                        // Configure translator
+                        $translator = $this->setupTranslator(
+                            $file,
+                            $chunk,
+                            $referenceStringList,
+                            $locale,
+                            $globalContext
+                        );
+
+                        try {
+                            // Execute translation
+                            $translatedItems = $translator->translate();
+                            $localeTranslatedCount += count($translatedItems);
+                            $totalTranslatedCount += count($translatedItems);
+
+                            // Save translation results - display is handled by onTranslated
+                            foreach ($translatedItems as $item) {
+                                $targetStringTransformer->updateString($item->key, $item->translated);
+                            }
+
+                            // Display number of saved items
+                            $this->info($this->colors['green'] . "  ✓ " . $this->colors['reset'] . "{$localeTranslatedCount} strings saved.");
+
+                            // Calculate and display cost
+                            $this->displayCostEstimation($translator);
+
+                            // Accumulate token usage
+                            $usage = $translator->getTokenUsage();
+                            $this->updateTokenUsageTotals($usage);
+
+                        } catch (\Exception $e) {
+                            $this->error("Translation failed: " . $e->getMessage());
+                        }
+                    });
+            }
+
+            // Display translation summary for each language
+            $this->displayTranslationSummary($locale, $localeFileCount, $localeStringCount, $localeTranslatedCount);
+        }
+
+        // 전체 번역 완료 메시지
+        $this->line("\n" . $this->colors['green_bg'] . $this->colors['white'] . $this->colors['bold'] . " All translations completed " . $this->colors['reset']);
+        $this->line($this->colors['yellow'] . "Total files processed: " . $this->colors['reset'] . $fileCount);
+        $this->line($this->colors['yellow'] . "Total strings found: " . $this->colors['reset'] . $totalStringCount);
+        $this->line($this->colors['yellow'] . "Total strings translated: " . $this->colors['reset'] . $totalTranslatedCount);
+    }
+
+    /**
+     * 비용 계산 및 표시
+     */
+    protected function displayCostEstimation(AIProvider $translator): void
+    {
+        $usage = $translator->getTokenUsage();
+        $printer = new TokenUsagePrinter($translator->getModel());
+        $printer->printTokenUsageSummary($this, $usage);
+        $printer->printCostEstimation($this, $usage);
+    }
+
+    /**
+     * 파일 정보 표시
+     */
+    protected function displayFileInfo(string $sourceFile, string $locale, string $outputFile): void
+    {
+        $this->line("\n" . $this->colors['purple_bg'] . $this->colors['white'] . $this->colors['bold'] . " File Translation " . $this->colors['reset']);
+        $this->line($this->colors['yellow'] . "  File: " .
+            $this->colors['reset'] . $this->colors['bold'] . basename($sourceFile) .
+            $this->colors['reset']);
+        $this->line($this->colors['yellow'] . "  Language: " .
+            $this->colors['reset'] . $this->colors['bold'] . $locale .
+            $this->colors['reset']);
+        $this->line($this->colors['gray'] . "  Source: " . $sourceFile . $this->colors['reset']);
+        $this->line($this->colors['gray'] . "  Target: " . $outputFile . $this->colors['reset']);
+    }
+
+    /**
+     * 번역 완료 요약 표시
+     */
+    protected function displayTranslationSummary(string $locale, int $fileCount, int $stringCount, int $translatedCount): void
+    {
+        $this->line("\n" . str_repeat('─', 80));
+        $this->line($this->colors['green_bg'] . $this->colors['white'] . $this->colors['bold'] . " Translation Complete: {$locale} " . $this->colors['reset']);
+        $this->line($this->colors['yellow'] . "Files processed: " . $this->colors['reset'] . $fileCount);
+        $this->line($this->colors['yellow'] . "Strings found: " . $this->colors['reset'] . $stringCount);
+        $this->line($this->colors['yellow'] . "Strings translated: " . $this->colors['reset'] . $translatedCount);
+
+        // Display accumulated token usage
+        if ($this->tokenUsage['total_tokens'] > 0) {
+            $this->line("\n" . $this->colors['blue_bg'] . $this->colors['white'] . $this->colors['bold'] . " Total Token Usage " . $this->colors['reset']);
+            $this->line($this->colors['yellow'] . "Input Tokens: " . $this->colors['reset'] . $this->colors['green'] . $this->tokenUsage['input_tokens'] . $this->colors['reset']);
+            $this->line($this->colors['yellow'] . "Output Tokens: " . $this->colors['reset'] . $this->colors['green'] . $this->tokenUsage['output_tokens'] . $this->colors['reset']);
+            $this->line($this->colors['yellow'] . "Total Tokens: " . $this->colors['reset'] . $this->colors['bold'] . $this->colors['purple'] . $this->tokenUsage['total_tokens'] . $this->colors['reset']);
+        }
+    }
+
+    /**
+     * 레퍼런스 번역 로드 (모든 파일에서)
+     */
+    protected function loadReferenceTranslations(string $file, string $targetLocale, array $sourceStringList): array
+    {
+        // 타겟 언어와 레퍼런스 언어들을 모두 포함
+        $allReferenceLocales = array_merge([$targetLocale], $this->referenceLocales);
+        $langDirectory = config('ai-translator.source_directory');
+        $currentFileName = basename($file);
+
+        return collect($allReferenceLocales)
+            ->filter(fn($referenceLocale) => $referenceLocale !== $this->sourceLocale)
+            ->map(function ($referenceLocale) use ($langDirectory, $file, $currentFileName) {
+                $referenceLocaleDir = $this->getOutputDirectoryLocale($referenceLocale);
+
+                if (!is_dir($referenceLocaleDir)) {
+                    $this->line($this->colors['gray'] . "    ℹ Reference directory not found: {$referenceLocale}" . $this->colors['reset']);
+                    return null;
+                }
+
+                // 해당 로케일 디렉토리의 모든 PO 파일 가져오기
+                $referenceFiles = glob("{$referenceLocaleDir}/*.po") ?: [];
+
+                if (empty($referenceFiles)) {
+                    $this->line($this->colors['gray'] . "    ℹ Reference file not found: {$referenceLocale}" . $this->colors['reset']);
+                    return null;
+                }
+
+                $this->line($this->colors['blue'] . "    ℹ Loading reference: " .
+                    $this->colors['reset'] . "{$referenceLocale} - " . count($referenceFiles) . " files");
+
+                // 유사한 이름의 파일을 먼저 처리하여 컨텍스트 관련성 향상
+                usort($referenceFiles, function ($a, $b) use ($currentFileName) {
+                    $similarityA = similar_text($currentFileName, basename($a));
+                    $similarityB = similar_text($currentFileName, basename($b));
+                    return $similarityB <=> $similarityA;
+                });
+
+                $allReferenceStrings = [];
+                $processedFiles = 0;
+
+                foreach ($referenceFiles as $referenceFile) {
+                    try {
+                        $referenceTransformer = $this->createTransformer($referenceFile);
+                        $referenceStringList = $referenceTransformer->flatten();
+
+                        if (empty($referenceStringList)) {
+                            continue;
+                        }
+
+                        // 우선순위 적용 (필요한 경우)
+                        if (count($referenceStringList) > 50) {
+                            $referenceStringList = $this->getPrioritizedReferenceStrings($referenceStringList, 50);
+                        }
+
+                        $allReferenceStrings = array_merge($allReferenceStrings, $referenceStringList);
+                        $processedFiles++;
+                    } catch (\Exception $e) {
+                        $this->line($this->colors['gray'] . "    ⚠ Reference file loading failed: " . basename($referenceFile) . $this->colors['reset']);
+                        continue;
+                    }
+                }
+
+                if (empty($allReferenceStrings)) {
+                    return null;
+                }
+
+                return [
+                    'locale' => $referenceLocale,
+                    'strings' => $allReferenceStrings,
+                ];
+            })
+            ->filter()
+            ->values()
+            ->toArray();
+    }
+
+    /**
+     * 레퍼런스 문자열에 우선순위 적용
+     */
+    protected function getPrioritizedReferenceStrings(array $strings, int $maxItems): array
+    {
+        $prioritized = [];
+
+        // 1. 짧은 문자열 우선 (UI 요소, 버튼 등)
+        foreach ($strings as $key => $value) {
+            if (strlen($value) < 50 && count($prioritized) < $maxItems * 0.7) {
+                $prioritized[$key] = $value;
+            }
+        }
+
+        // 2. 나머지 항목 추가
+        foreach ($strings as $key => $value) {
+            if (!isset($prioritized[$key]) && count($prioritized) < $maxItems) {
+                $prioritized[$key] = $value;
+            }
+
+            if (count($prioritized) >= $maxItems) {
+                break;
+            }
+        }
+
+        return $prioritized;
+    }
+
+    /**
+     * 전역 번역 컨텍스트 가져오기
+     */
+    protected function getGlobalContext(string $file, string $locale, int $maxContextItems): array
+    {
+        if ($maxContextItems <= 0) {
+            return [];
+        }
+
+        $contextProvider = new PoTranslationContextProvider();
+        $globalContext = $contextProvider->getGlobalTranslationContext(
+            $this->sourceLocale,
+            $locale,
+            $file,
+            $maxContextItems
+        );
+
+        if (!empty($globalContext)) {
+            $contextItemCount = collect($globalContext)->map(fn($items) => count($items))->sum();
+            $this->info($this->colors['blue'] . "    ℹ Using global context: " .
+                $this->colors['reset'] . count($globalContext) . " files, " .
+                $contextItemCount . " items");
+        } else {
+            $this->line($this->colors['gray'] . "    ℹ No global context available" . $this->colors['reset']);
+        }
+
+        return $globalContext;
+    }
+
+    /**
+     * 번역기 설정
+     */
+    protected function setupTranslator(
+        string $file,
+        \Illuminate\Support\Collection $chunk,
+        array $referenceStringList,
+        string $locale,
+        array $globalContext
+    ): AIProvider {
+        // 파일 정보 표시
+        $outputFile = $this->getOutputDirectoryLocale($locale) . '/' . basename($file);
+        $this->displayFileInfo($file, $locale, $outputFile);
+
+        // 레퍼런스 정보를 적절한 형식으로 변환
+        $references = [];
+        foreach ($referenceStringList as $reference) {
+            $referenceLocale = $reference['locale'];
+            $referenceStrings = $reference['strings'];
+            $references[$referenceLocale] = $referenceStrings;
+        }
+
+        // AIProvider 인스턴스 생성
+        $translator = new AIProvider(
+            $file,
+            $chunk->toArray(),
+            $this->sourceLocale,
+            $locale,
+            $references,
+            [],  // additionalRules
+            $globalContext  // globalTranslationContext
+        );
+
+        $translator->setOnThinking(function ($thinking) {
+            echo $this->colors['gray'] . $thinking . $this->colors['reset'];
+        });
+
+        $translator->setOnThinkingStart(function () {
+            $this->line($this->colors['gray'] . "    " . "🧠 AI Thinking..." . $this->colors['reset']);
+        });
+
+        $translator->setOnThinkingEnd(function () {
+            $this->line($this->colors['gray'] . "    " . "Thinking completed." . $this->colors['reset']);
+        });
+
+        // 번역 진행 상황 표시를 위한 콜백 설정
+        $translator->setOnTranslated(function ($item, $status, $translatedItems) use ($chunk) {
+            if ($status === TranslationStatus::COMPLETED) {
+                $totalCount = $chunk->count();
+                $completedCount = count($translatedItems);
+
+                $this->line($this->colors['cyan'] . "  ⟳ " .
+                    $this->colors['reset'] . $item->key .
+                    $this->colors['gray'] . " → " .
+                    $this->colors['reset'] . $item->translated .
+                    $this->colors['gray'] . " ({$completedCount}/{$totalCount})" .
+                    $this->colors['reset']);
+            }
+        });
+
+        // 토큰 사용량 콜백 설정
+        $translator->setOnTokenUsage(function ($usage) {
+            $isFinal = $usage['final'] ?? false;
+            $inputTokens = $usage['input_tokens'] ?? 0;
+            $outputTokens = $usage['output_tokens'] ?? 0;
+            $totalTokens = $usage['total_tokens'] ?? 0;
+
+            // 실시간 토큰 사용량 표시
+            $this->line($this->colors['gray'] . "    Tokens: " .
+                "Input=" . $this->colors['green'] . $inputTokens . $this->colors['gray'] . ", " .
+                "Output=" . $this->colors['green'] . $outputTokens . $this->colors['gray'] . ", " .
+                "Total=" . $this->colors['purple'] . $totalTokens . $this->colors['gray'] .
+                $this->colors['reset']);
+        });
+
+        // 프롬프트 로깅 콜백 설정
+        if ($this->option('show-prompt')) {
+            $translator->setOnPromptGenerated(function ($prompt, PromptType $type) {
+                $typeText = match ($type) {
+                    PromptType::SYSTEM => '🤖 System Prompt',
+                    PromptType::USER => '👤 User Prompt',
+                };
+
+                print ("\n    {$typeText}:\n");
+                print ($this->colors['gray'] . "    " . str_replace("\n", $this->colors['reset'] . "\n    " . $this->colors['gray'], $prompt) . $this->colors['reset'] . "\n");
+            });
+        }
+
+        return $translator;
+    }
+
+    /**
+     * 토큰 사용량 총계 업데이트
+     */
+    protected function updateTokenUsageTotals(array $usage): void
+    {
+        $this->tokenUsage['input_tokens'] += ($usage['input_tokens'] ?? 0);
+        $this->tokenUsage['output_tokens'] += ($usage['output_tokens'] ?? 0);
+        $this->tokenUsage['total_tokens'] =
+            $this->tokenUsage['input_tokens'] +
+            $this->tokenUsage['output_tokens'];
+    }
+
+    protected function createTransformer(string $file)
+    {
+        return new PoLangTransformer($file);
+    }
+
+    /**
+     * 사용 가능한 로케일 목록 가져오기
+     *
+     * @return array|string[]
+     */
+    public function getExistingLocales(): array
+    {
+        $root = $this->sourceDirectory;
+        $directories = array_diff(scandir($root), ['.', '..']);
+        // 디렉토리만 필터링
+        $directories = array_filter($directories, function ($directory) use ($root) {
+            return is_dir($root . '/' . $directory);
+        });
+        return collect($directories)->values()->toArray();
+    }
+
+    /**
+     * 출력 디렉토리 경로 가져오기
+     */
+    public function getOutputDirectoryLocale(string $locale): string
+    {
+        return config('ai-translator.source_directory') . '/' . $locale;
+    }
+
+    /**
+     * 문자열 파일 경로 목록 가져오기
+     */
+    public function getStringFilePaths(string $locale): array
+    {
+        $files = [];
+        $root = $this->sourceDirectory . '/' . $locale;
+        $directories = array_diff(scandir($root), ['.', '..']);
+        foreach ($directories as $directory) {
+            if (pathinfo($directory, PATHINFO_EXTENSION) !== 'po') {
+                continue;
+            }
+            $files[] = $root . '/' . $directory;
+        }
+        return $files;
+    }
+
+    /**
+     * 지정된 로케일 검증 및 필터링
+     */
+    protected function validateAndFilterLocales(array $specifiedLocales, array $availableLocales): array
+    {
+        $validLocales = [];
+        $invalidLocales = [];
+
+        foreach ($specifiedLocales as $locale) {
+            if (in_array($locale, $availableLocales)) {
+                $validLocales[] = $locale;
+            } else {
+                $invalidLocales[] = $locale;
+            }
+        }
+
+        if (!empty($invalidLocales)) {
+            $this->warn("The following locales are invalid or not available: " . implode(', ', $invalidLocales));
+            $this->info("Available locales: " . implode(', ', $availableLocales));
+        }
+
+        return $validLocales;
+    }
+}

--- a/src/Transformers/PoLangTransformer.php
+++ b/src/Transformers/PoLangTransformer.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Kargnas\LaravelAiTranslator\Transformers;
+
+class PoLangTransformer
+{
+    private array $entries = [];
+    private string $filePath;
+    private string $sourceLanguage;
+
+    public function __construct(string $filePath, string $sourceLanguage = 'en')
+    {
+        $this->filePath = $filePath;
+        $this->sourceLanguage = $sourceLanguage;
+        $this->loadContent();
+    }
+
+    private function loadContent(): void
+    {
+        if (!file_exists($this->filePath)) {
+            $this->entries = [];
+            return;
+        }
+
+        $this->entries = [];
+        $lines = file($this->filePath, FILE_IGNORE_NEW_LINES);
+        $currentId = null;
+        foreach ($lines as $line) {
+            if (preg_match('/^msgid\s+"(.*)"/', $line, $m)) {
+                $currentId = stripcslashes($m[1]);
+            } elseif ($currentId !== null && preg_match('/^msgstr\s+"(.*)"/', $line, $m)) {
+                $this->entries[$currentId] = stripcslashes($m[1]);
+                $currentId = null;
+            }
+        }
+    }
+
+    public function flatten(): array
+    {
+        return $this->entries;
+    }
+
+    public function isTranslated(string $key): bool
+    {
+        return isset($this->entries[$key]) && $this->entries[$key] !== '';
+    }
+
+    public function updateString(string $key, string $translated): void
+    {
+        $this->entries[$key] = $translated;
+        $this->saveToFile();
+    }
+
+    private function saveToFile(): void
+    {
+        $timestamp = date('Y-m-d H:i:s T');
+        $lines = [
+            '# WARNING: This is an auto-generated file.',
+            '# Do not modify this file manually as your changes will be lost.',
+            "# This file was automatically translated from {$this->sourceLanguage} at {$timestamp}.",
+        ];
+
+        foreach ($this->entries as $id => $str) {
+            $idEsc = addcslashes($id, "\n\r\t\"");
+            $strEsc = addcslashes($str, "\n\r\t\"");
+            $lines[] = '';
+            $lines[] = "msgid \"{$idEsc}\"";
+            $lines[] = "msgstr \"{$strEsc}\"";
+        }
+
+        file_put_contents($this->filePath, implode("\n", $lines) . "\n");
+    }
+}


### PR DESCRIPTION
## Summary
- revert modifications to the existing translator commands
- add `TranslatePoStrings` and `TranslatePoFileCommand` for gettext PO files
- implement `PoTranslationContextProvider`
- document PO command usage in README

## Testing
- No tests run as PHP execution isn't supported in Codex