### PR TITLE
refactor: Replace global \Log with imported Log facade

### DIFF
--- a/src/AI/Clients/AnthropicClient.php
+++ b/src/AI/Clients/AnthropicClient.php
@@ -4,6 +4,7 @@ namespace Kargnas\LaravelAiTranslator\AI\Clients;
 
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 /**
  * HTTP client for calling Anthropic (Claude) server
@@ -101,7 +102,7 @@ class AnthropicClient
                 if (config('app.debug', false) || config('ai-translator.debug', false)) {
                     $eventType = $parsedData['type'] ?? 'unknown';
                     if (in_array($eventType, ['message_start', 'message_stop', 'message_delta']) && ! isset($parsedData['__logged'])) {
-                        \Log::debug("Anthropic API Raw Event: {$eventType}", json_decode(json_encode($parsedData), true));
+                        Log::debug("Anthropic API Raw Event: {$eventType}", json_decode(json_encode($parsedData), true));
                         $parsedData['__logged'] = true;
                     }
                 }

--- a/src/Console/CrowdIn/Services/CrowdinAsyncApiService.php
+++ b/src/Console/CrowdIn/Services/CrowdinAsyncApiService.php
@@ -5,6 +5,7 @@ namespace Kargnas\LaravelAiTranslator\Console\CrowdIn\Services;
 use GuzzleHttp\Client;
 use GuzzleHttp\Promise;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
 
 class CrowdinAsyncApiService
 {
@@ -156,7 +157,7 @@ class CrowdinAsyncApiService
                     continue;
                 }
 
-                \Log::error('Failed to process translations chunk', [
+                Log::error('Failed to process translations chunk', [
                     'error' => $e->getMessage(),
                     'chunk' => $chunk,
                 ]);
@@ -178,7 +179,7 @@ class CrowdinAsyncApiService
 
             return $userData['data']['id'] ?? throw new \RuntimeException('Failed to get user ID from response');
         } catch (\Exception $e) {
-            \Log::error('Failed to get current user ID', [
+            Log::error('Failed to get current user ID', [
                 'error' => $e->getMessage(),
             ]);
             throw new \RuntimeException('Failed to get current user ID: '.$e->getMessage());

--- a/src/Console/CrowdIn/Services/TranslationService.php
+++ b/src/Console/CrowdIn/Services/TranslationService.php
@@ -8,6 +8,7 @@ use CrowdinApiClient\Model\SourceString;
 use CrowdinApiClient\Model\StringTranslationApproval;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Kargnas\LaravelAiTranslator\AI\AIProvider;
 use Kargnas\LaravelAiTranslator\AI\TranslationContextProvider;
 use Kargnas\LaravelAiTranslator\Enums\PromptType;
@@ -395,7 +396,7 @@ class TranslationService
             } else {
                 // API call failure is treated as non-duplicate
                 $nonDuplicates[] = $item;
-                \Log::warning("Failed to check duplicates for {$key}", [
+                Log::warning("Failed to check duplicates for {$key}", [
                     'error' => $result['reason']->getMessage(),
                 ]);
             }
@@ -561,7 +562,7 @@ class TranslationService
             $this->command->line("    - Successfully added: {$successCount}");
             $this->command->line('    - Failed: '.(count($checkResult['nonDuplicates']) - $successCount));
 
-            \Log::info('Translation process completed', [
+            Log::info('Translation process completed', [
                 'total' => count($translated),
                 'duplicates' => $duplicateCount,
                 'success' => $successCount,
@@ -571,7 +572,7 @@ class TranslationService
             $errorMessage = 'Translation processing failed';
             $errorDetails = $e->getMessage();
 
-            \Log::error($errorMessage, [
+            Log::error($errorMessage, [
                 'error' => $errorDetails,
                 'file' => __FILE__,
                 'line' => __LINE__,


### PR DESCRIPTION
Fixes #45

## Changes
- Replace all `\Log::` calls with `Log::`
- Add proper import statement `use Illuminate\Support\Facades\Log;`

## Files Modified
- `src/AI/Clients/AnthropicClient.php`
- `src/Console/CrowdIn/Services/CrowdinAsyncApiService.php`
- `src/Console/CrowdIn/Services/TranslationService.php`

Generated with [Claude Code](https://claude.ai/code)