### PR TITLE
Add structured JSON parallel translation feature

### DIFF
--- a/config/ai-translator.php
+++ b/config/ai-translator.php
@@ -9,7 +9,7 @@ return [
 
     'ai' => [
         'provider' => 'anthropic',
-        'model' => 'claude-3-5-sonnet-latest', // Best result. Recommend for production.
+        'model' => 'claude-sonnet-4-20250514', // Best result. Recommend for production.
         'api_key' => env('ANTHROPIC_API_KEY'),
 
         // claude-3-haiku
@@ -35,8 +35,8 @@ return [
         // Additional options
         // 'retries' => 5,
         // 'max_tokens' => 4096,
-        // 'use_extended_thinking' => false, // Extended Thinking 기능 사용 여부 (claude-3-7-sonnet-latest 모델만 지원)
-        // 'disable_stream' => true, // Disable streaming mode for better error messages
+        'use_extended_thinking' => true, // Extended Thinking 기능 사용 여부 (claude-3-7-sonnet-latest 모델만 지원)
+        'disable_stream' => true, // Disable streaming mode for better error messages
 
         // 'prompt_custom_system_file_path' => null, // Full path to your own custom prompt-system.txt - i.e. resource_path('prompt-system.txt')
         // 'prompt_custom_user_file_path' => null, // Full path to your own custom prompt-user.txt - i.e. resource_path('prompt-user.txt')

--- a/config/ai-translator.php
+++ b/config/ai-translator.php
@@ -47,7 +47,7 @@ return [
     // 'skip_files' => [],
 
     // If set to true, translations will be saved as flat arrays using dot notation keys. If set to false, translations will be saved as multi-dimensional arrays.
-    'dot_notation' => true,
+    'dot_notation' => false,
 
     // You can add additional custom locale names here.
     // Example: 'en_us', 'en-us', 'en_US', 'en-US'

--- a/src/AI/AIProvider.php
+++ b/src/AI/AIProvider.php
@@ -38,6 +38,10 @@ class AIProvider
 
     protected int $totalTokens = 0;
 
+    protected int $cacheCreationTokens = 0;
+
+    protected int $cacheReadTokens = 0;
+
     // Callback properties
     protected $onTranslated = null;
 
@@ -172,34 +176,74 @@ class AIProvider
             Log::debug("AIProvider: Using translation context - {$contextFileCount} files, {$contextItemCount} items");
 
             $translationContext = collect($this->globalTranslationContext)->map(function ($translations, $file) {
-                // Remove .php extension from filename
-                $rootKey = pathinfo($file, PATHINFO_FILENAME);
-                $itemCount = count($translations);
+                // Handle both PHP and JSON context structures
+                $isJsonContext = isset($translations['source']) && isset($translations['target']);
 
-                Log::debug("AIProvider: Including context file - {$rootKey}: {$itemCount} items");
+                if ($isJsonContext) {
+                    // JSON context structure from JSONTranslationContextProvider
+                    $sourceStrings = $translations['source'];
+                    $targetStrings = $translations['target'];
 
-                $translationsText = collect($translations)->map(function ($item, $key) use ($rootKey) {
-                    $sourceText = $item['source'] ?? '';
-
-                    if (empty($sourceText)) {
+                    if (empty($sourceStrings)) {
                         return null;
                     }
 
-                    $text = "`{$rootKey}.{$key}`: src=\"\"\"{$sourceText}\"\"\"";
+                    $itemCount = count($sourceStrings);
+                    Log::debug("AIProvider: Including context file - {$file}: {$itemCount} items");
 
-                    // Check reference information
-                    $referenceKey = $key;
-                    foreach ($this->references as $locale => $strings) {
-                        if (isset($strings[$referenceKey]) && ! empty($strings[$referenceKey])) {
-                            $text .= "\n    {$locale}=\"\"\"{$strings[$referenceKey]}\"\"\"";
+                    $translationsText = collect($sourceStrings)->map(function ($sourceText, $key) use ($targetStrings) {
+                        if (empty($sourceText)) {
+                            return null;
                         }
-                    }
 
-                    return $text;
-                })->filter()->implode("\n");
+                        $text = "    <item>\n";
+                        $text .= "      <key>{$key}</key>\n";
+                        $text .= "      <source><![CDATA[{$sourceText}]]></source>\n";
 
-                return empty($translationsText) ? '' : "## `{$rootKey}`\n{$translationsText}";
-            })->filter()->implode("\n\n");
+                        if (isset($targetStrings[$key]) && ! empty($targetStrings[$key])) {
+                            $text .= "      <target><![CDATA[{$targetStrings[$key]}]]></target>\n";
+                        }
+
+                        $text .= '    </item>';
+
+                        return $text;
+                    })->filter()->implode("\n");
+
+                    return empty($translationsText) ? '' : "  <file name=\"{$file}\">\n{$translationsText}\n  </file>";
+                } else {
+                    // PHP context structure from TranslationContextProvider
+                    $rootKey = pathinfo($file, PATHINFO_FILENAME);
+                    $itemCount = count($translations);
+                    Log::debug("AIProvider: Including context file - {$rootKey}: {$itemCount} items");
+
+                    $translationsText = collect($translations)->map(function ($item, $key) use ($rootKey) {
+                        $sourceText = $item['source'] ?? '';
+
+                        if (empty($sourceText)) {
+                            return null;
+                        }
+
+                        $text = "    <item>\n";
+                        $text .= "      <key>{$rootKey}.{$key}</key>\n";
+                        $text .= "      <source><![CDATA[{$sourceText}]]></source>\n";
+
+                        if (isset($item['target']) && ! empty($item['target'])) {
+                            $text .= "      <target><![CDATA[{$item['target']}]]></target>\n";
+                        }
+
+                        $text .= '    </item>';
+
+                        return $text;
+                    })->filter()->implode("\n");
+
+                    return empty($translationsText) ? '' : "  <file name=\"{$rootKey}\">\n{$translationsText}\n  </file>";
+                }
+            })->filter()->implode("\n");
+
+            // Wrap in global_context XML tags
+            if (! empty($translationContext)) {
+                $translationContext = "<global_context>\n{$translationContext}\n</global_context>";
+            }
 
             $contextLength = strlen($translationContext);
             Log::debug("AIProvider: Generated context size - {$contextLength} bytes");
@@ -241,16 +285,21 @@ class AIProvider
             'parentKey' => pathinfo($this->filename, PATHINFO_FILENAME),
             'keys' => collect($this->strings)->keys()->implode('`, `'),
             'strings' => collect($this->strings)->map(function ($string, $key) {
-                if (is_string($string)) {
-                    return "  - `{$key}`: \"\"\"{$string}\"\"\"";
-                } else {
-                    $text = "  - `{$key}`: \"\"\"{$string['text']}\"\"\"";
-                    if (isset($string['context'])) {
-                        $text .= "\n    - Context: \"\"\"{$string['context']}\"\"\"";
-                    }
+                $text = "  <string>\n";
+                $text .= "    <key>{$key}</key>\n";
 
-                    return $text;
+                if (is_string($string)) {
+                    $text .= "    <source><![CDATA[{$string}]]></source>\n";
+                } else {
+                    $text .= "    <source><![CDATA[{$string['text']}]]></source>\n";
+                    if (isset($string['context'])) {
+                        $text .= "    <context><![CDATA[{$string['context']}]]></context>\n";
+                    }
                 }
+
+                $text .= '  </string>';
+
+                return $text;
             })->implode("\n"),
         ]);
 
@@ -521,9 +570,6 @@ class AIProvider
         // Prepare request data
         $requestData = [
             'model' => $this->configModel,
-            'messages' => [
-                ['role' => 'user', 'content' => $this->getUserPrompt()],
-            ],
             'system' => [
                 [
                     'type' => 'text',
@@ -532,6 +578,9 @@ class AIProvider
                         'type' => 'ephemeral',
                     ],
                 ],
+            ],
+            'messages' => [
+                ['role' => 'user', 'content' => $this->getUserPrompt()],
             ],
         ];
 
@@ -545,7 +594,7 @@ class AIProvider
         }
 
         // Set up Extended Thinking
-        if ($useExtendedThinking && preg_match('/^claude\-3\-7\-/', $this->configModel)) {
+        if ($useExtendedThinking && preg_match('/^claude.*(3\-7|4)/', $this->configModel)) {
             $requestData['thinking'] = [
                 'type' => 'enabled',
                 'budget_tokens' => 10000,
@@ -745,6 +794,14 @@ class AIProvider
                 $this->totalTokens = $this->inputTokens + $this->outputTokens;
             }
 
+            // 캐시 토큰 추적
+            if (isset($response['cache_creation_input_tokens'])) {
+                $this->cacheCreationTokens = (int) $response['cache_creation_input_tokens'];
+            }
+            if (isset($response['cache_read_input_tokens'])) {
+                $this->cacheReadTokens = (int) $response['cache_read_input_tokens'];
+            }
+
             $responseText = $response['content'][0]['text'];
             $responseParser->parse($responseText);
 
@@ -814,8 +871,8 @@ class AIProvider
         return [
             'input_tokens' => $this->inputTokens,
             'output_tokens' => $this->outputTokens,
-            'cache_creation_input_tokens' => null,
-            'cache_read_input_tokens' => null,
+            'cache_creation_input_tokens' => $this->cacheCreationTokens,
+            'cache_read_input_tokens' => $this->cacheReadTokens,
             'total_tokens' => $this->totalTokens,
         ];
     }
@@ -861,6 +918,14 @@ class AIProvider
             // 유형 2: message 안에 usage가 있는 경우
             if (isset($data['message']['usage'])) {
                 $this->extractTokensFromUsage($data['message']['usage']);
+            }
+
+            // 캐시 토큰 정보 추출
+            if (isset($data['message']['cache_creation_input_tokens'])) {
+                $this->cacheCreationTokens = (int) $data['message']['cache_creation_input_tokens'];
+            }
+            if (isset($data['message']['cache_read_input_tokens'])) {
+                $this->cacheReadTokens = (int) $data['message']['cache_read_input_tokens'];
             }
 
             // 유형 3: message.content_policy.input_tokens, output_tokens가 있는 경우

--- a/src/AI/AIProvider.php
+++ b/src/AI/AIProvider.php
@@ -588,7 +588,7 @@ class AIProvider
 
         if (preg_match('/^claude\-3\-5\-/', $this->configModel)) {
             $defaultMaxTokens = 8192;
-        } elseif (preg_match('/^claude\-3\-7\-/', $this->configModel)) {
+        } elseif (preg_match('/^claude.*(3\-7|4)/', $this->configModel)) {
             // @TODO: if add betas=["output-128k-2025-02-19"], then 128000
             $defaultMaxTokens = 64000;
         }

--- a/src/AI/AIProvider.php
+++ b/src/AI/AIProvider.php
@@ -288,13 +288,13 @@ class AIProvider
                 $text = "  <string>\n";
                 $text .= "    <key>{$key}</key>\n";
 
-                if (is_string($string)) {
-                    $text .= "    <source><![CDATA[{$string}]]></source>\n";
-                } else {
+                if (\is_array($string)) {
                     $text .= "    <source><![CDATA[{$string['text']}]]></source>\n";
                     if (isset($string['context'])) {
                         $text .= "    <context><![CDATA[{$string['context']}]]></context>\n";
                     }
+                } else {
+                    $text .= "    <source><![CDATA[{$string}]]></source>\n";
                 }
 
                 $text .= '  </string>';

--- a/src/AI/Clients/AnthropicClient.php
+++ b/src/AI/Clients/AnthropicClient.php
@@ -41,11 +41,13 @@ class AnthropicClient
      */
     public function request(string $method, string $endpoint, array $data = []): array
     {
+        $timeout = 1800; // 30 minutes
+        
         $response = Http::withHeaders([
             'x-api-key' => $this->apiKey,
             'anthropic-version' => $this->apiVersion,
             'content-type' => 'application/json',
-        ])->$method("{$this->baseUrl}/{$endpoint}", $data);
+        ])->timeout($timeout)->$method("{$this->baseUrl}/{$endpoint}", $data);
 
         if (! $response->successful()) {
             $statusCode = $response->status();
@@ -283,6 +285,9 @@ class AnthropicClient
             'accept: application/json',
         ];
 
+        // Set timeout to 30 minutes for streaming
+        $timeout = 1800; // 30 minutes
+
         // Initialize cURL
         $ch = curl_init();
 
@@ -291,7 +296,7 @@ class AnthropicClient
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, false);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, strtoupper($method));
-        curl_setopt($ch, CURLOPT_TIMEOUT, 3000);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
 
         if (strtoupper($method) !== 'GET') {
             curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));

--- a/src/AI/Clients/AnthropicClient.php
+++ b/src/AI/Clients/AnthropicClient.php
@@ -291,7 +291,7 @@ class AnthropicClient
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, false);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, strtoupper($method));
-        curl_setopt($ch, CURLOPT_TIMEOUT, 300);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 3000);
 
         if (strtoupper($method) !== 'GET') {
             curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));

--- a/src/AI/Clients/GeminiClient.php
+++ b/src/AI/Clients/GeminiClient.php
@@ -11,7 +11,17 @@ class GeminiClient
     public function __construct(string $apiKey)
     {
         $this->apiKey = $apiKey;
-        $this->client = \Gemini::client($apiKey);
+        
+        // Set timeout to 30 minutes
+        $timeout = 1800; // 30 minutes
+        
+        // Create client with timeout configuration
+        $this->client = \Gemini::factory()
+            ->withApiKey($apiKey)
+            ->withHttpClient(new \GuzzleHttp\Client([
+                'timeout' => $timeout,
+            ]))
+            ->make();
     }
 
     public function request(string $model, array $contents): array

--- a/src/AI/Clients/OpenAIClient.php
+++ b/src/AI/Clients/OpenAIClient.php
@@ -30,10 +30,12 @@ class OpenAIClient
      */
     public function request(string $method, string $endpoint, array $data = []): array
     {
+        $timeout = 1800; // 30 minutes
+        
         $response = Http::withHeaders([
             'Authorization' => 'Bearer '.$this->apiKey,
             'Content-Type' => 'application/json',
-        ])->$method("{$this->baseUrl}/{$endpoint}", $data);
+        ])->timeout($timeout)->$method("{$this->baseUrl}/{$endpoint}", $data);
 
         if (! $response->successful()) {
             throw new \Exception("OpenAI API error: {$response->body()}");
@@ -173,8 +175,10 @@ class OpenAIClient
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, strtoupper($method));
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 120);
+        
+        $timeout = 1800; // 30 minutes
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30); // Keep connection timeout at 30 seconds
+        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
 
         if (strtoupper($method) !== 'GET') {
             curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));

--- a/src/AI/JSONTranslationContextProvider.php
+++ b/src/AI/JSONTranslationContextProvider.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Kargnas\LaravelAiTranslator\AI;
+
+use Kargnas\LaravelAiTranslator\Transformers\JSONLangTransformer;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Purpose: Provides global translation context for JSON files with nested directory structure
+ * Objectives:
+ * - Collect existing translations from already translated JSON files
+ * - Support recursive directory traversal for nested JSON structures
+ * - Include both source and target language strings for context
+ * - Prioritize most relevant translations for context
+ * - Manage context size to prevent context window overflows
+ */
+class JSONTranslationContextProvider
+{
+    /**
+     * Get global translation context for improving consistency
+     *
+     * @param  string  $sourceLocale  Source language locale code
+     * @param  string  $targetLocale  Target language locale code
+     * @param  string  $currentFilePath  Current file being translated
+     * @param  int  $maxContextItems  Maximum number of context items to include (to prevent context overflow)
+     * @return array Context data organized by file with both source and target strings
+     */
+    public function getGlobalTranslationContext(
+        string $sourceLocale,
+        string $targetLocale,
+        string $currentFilePath,
+        int $maxContextItems = 100
+    ): array {
+        // Base directory path for language files
+        $langDirectory = config('ai-translator.source_directory');
+
+        // Configure source and target language directory paths
+        $sourceLocaleDir = $this->getLanguageDirectory($langDirectory, $sourceLocale);
+        $targetLocaleDir = $this->getLanguageDirectory($langDirectory, $targetLocale);
+
+        // Return empty array if source directory doesn't exist
+        if (! is_dir($sourceLocaleDir)) {
+            return [];
+        }
+
+        $currentFileName = basename($currentFilePath);
+        $context = [];
+        $totalContextItems = 0;
+        $processedFiles = 0;
+
+        // Get all JSON files from source directory recursively
+        $sourceFiles = $this->getAllJsonFiles($sourceLocaleDir);
+
+        // Return empty array if no files exist
+        if (empty($sourceFiles)) {
+            return [];
+        }
+
+        // Process similar named files first to improve context relevance
+        usort($sourceFiles, function ($a, $b) use ($currentFileName) {
+            $similarityA = similar_text($currentFileName, basename($a));
+            $similarityB = similar_text($currentFileName, basename($b));
+
+            return $similarityB <=> $similarityA;
+        });
+
+        foreach ($sourceFiles as $sourceFile) {
+            // Stop if maximum context items are reached
+            if ($totalContextItems >= $maxContextItems) {
+                break;
+            }
+
+            try {
+                // Calculate relative path to maintain directory structure
+                $relativePath = str_replace($sourceLocaleDir . '/', '', $sourceFile);
+                $targetFile = $targetLocaleDir . '/' . $relativePath;
+                $hasTargetFile = file_exists($targetFile);
+
+                // Get original strings from source file
+                $sourceTransformer = new JSONLangTransformer($sourceFile);
+                $sourceStrings = $sourceTransformer->flatten();
+
+                // Skip empty files
+                if (empty($sourceStrings)) {
+                    continue;
+                }
+
+                // Get target strings if target file exists
+                $targetStrings = [];
+                if ($hasTargetFile) {
+                    $targetTransformer = new JSONLangTransformer($targetFile);
+                    $targetStrings = $targetTransformer->flatten();
+                }
+
+                // Limit maximum items per file
+                $maxPerFile = min(20, intval($maxContextItems / max(count($sourceFiles) / 2, 1)) + 1);
+
+                // Prioritize high-priority items from longer files
+                if (count($sourceStrings) > $maxPerFile) {
+                    if ($hasTargetFile && ! empty($targetStrings)) {
+                        // If target exists, apply both source and target prioritization
+                        $prioritizedItems = $this->getPrioritizedStrings($sourceStrings, $targetStrings, $maxPerFile);
+                        $sourceStrings = $prioritizedItems['source'];
+                        $targetStrings = $prioritizedItems['target'];
+                    } else {
+                        // If no target exists, prioritize source items only
+                        $sourceStrings = $this->getPrioritizedSourceStrings($sourceStrings, $maxPerFile);
+                    }
+                }
+
+                // Add file context
+                $context[$relativePath] = [
+                    'source' => $sourceStrings,
+                    'target' => $targetStrings,
+                ];
+
+                $totalContextItems += count($sourceStrings);
+                $processedFiles++;
+            } catch (\Exception $e) {
+                // Silently skip files that cannot be processed
+                continue;
+            }
+        }
+
+        return $context;
+    }
+
+    /**
+     * Get all JSON files recursively from a directory
+     */
+    protected function getAllJsonFiles(string $directory): array
+    {
+        $files = [];
+        
+        if (!is_dir($directory)) {
+            return [];
+        }
+        
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+        
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'json') {
+                $files[] = $file->getPathname();
+            }
+        }
+        
+        return $files;
+    }
+
+    /**
+     * Get prioritized strings based on importance
+     *
+     * @param  array  $sourceStrings  Source language strings
+     * @param  array  $targetStrings  Target language strings  
+     * @param  int  $maxItems  Maximum number of items to return
+     * @return array Prioritized source and target strings
+     */
+    protected function getPrioritizedStrings(array $sourceStrings, array $targetStrings, int $maxItems): array
+    {
+        $prioritizedSource = [];
+        $prioritizedTarget = [];
+
+        // Priority 1: Short strings (UI elements, buttons, etc.)
+        // Exclude very long texts with many line breaks
+        foreach ($sourceStrings as $key => $value) {
+            // Skip very long texts (5+ line breaks)
+            if (substr_count($value, "\n") >= 5) {
+                continue;
+            }
+            
+            if (strlen($value) < 50 && count($prioritizedSource) < $maxItems * 0.7) {
+                $prioritizedSource[$key] = $value;
+                if (isset($targetStrings[$key])) {
+                    $prioritizedTarget[$key] = $targetStrings[$key];
+                }
+            }
+        }
+
+        // Priority 2: Add remaining items (excluding very long texts)
+        foreach ($sourceStrings as $key => $value) {
+            // Skip very long texts (5+ line breaks)
+            if (substr_count($value, "\n") >= 5) {
+                continue;
+            }
+            
+            if (! isset($prioritizedSource[$key]) && count($prioritizedSource) < $maxItems) {
+                $prioritizedSource[$key] = $value;
+                if (isset($targetStrings[$key])) {
+                    $prioritizedTarget[$key] = $targetStrings[$key];
+                }
+            }
+
+            if (count($prioritizedSource) >= $maxItems) {
+                break;
+            }
+        }
+
+        return [
+            'source' => $prioritizedSource,
+            'target' => $prioritizedTarget,
+        ];
+    }
+
+    /**
+     * Get prioritized source strings
+     *
+     * @param  array  $sourceStrings  Source language strings
+     * @param  int  $maxItems  Maximum number of items to return
+     * @return array Prioritized source strings
+     */
+    protected function getPrioritizedSourceStrings(array $sourceStrings, int $maxItems): array
+    {
+        $prioritized = [];
+
+        // Priority 1: Short strings (UI elements, buttons, etc.)
+        // Exclude very long texts with many line breaks
+        foreach ($sourceStrings as $key => $value) {
+            // Skip very long texts (5+ line breaks)
+            if (substr_count($value, "\n") >= 5) {
+                continue;
+            }
+            
+            if (strlen($value) < 50 && count($prioritized) < $maxItems * 0.7) {
+                $prioritized[$key] = $value;
+            }
+        }
+
+        // Priority 2: Add remaining items (excluding very long texts)
+        foreach ($sourceStrings as $key => $value) {
+            // Skip very long texts (5+ line breaks)
+            if (substr_count($value, "\n") >= 5) {
+                continue;
+            }
+            
+            if (! isset($prioritized[$key]) && count($prioritized) < $maxItems) {
+                $prioritized[$key] = $value;
+            }
+
+            if (count($prioritized) >= $maxItems) {
+                break;
+            }
+        }
+
+        return $prioritized;
+    }
+
+    /**
+     * Get language directory path
+     *
+     * @param  string  $baseDirectory  Base language directory
+     * @param  string  $locale  Locale code
+     * @return string Full directory path
+     */
+    protected function getLanguageDirectory(string $baseDirectory, string $locale): string
+    {
+        return $baseDirectory . '/' . $locale;
+    }
+}

--- a/src/AI/JSONTranslationContextProvider.php
+++ b/src/AI/JSONTranslationContextProvider.php
@@ -18,6 +18,13 @@ use RecursiveIteratorIterator;
 class JSONTranslationContextProvider
 {
     /**
+     * Constants for magic numbers
+     */
+    protected const MAX_LINE_BREAKS = 5;
+    protected const SHORT_STRING_LENGTH = 50;
+    protected const PRIORITY_RATIO = 0.7;
+
+    /**
      * Get global translation context for improving consistency
      *
      * @param  string  $sourceLocale  Source language locale code
@@ -168,11 +175,11 @@ class JSONTranslationContextProvider
         // Exclude very long texts with many line breaks
         foreach ($sourceStrings as $key => $value) {
             // Skip very long texts (5+ line breaks)
-            if (substr_count($value, "\n") >= 5) {
+            if ($this->isVeryLongText($value)) {
                 continue;
             }
             
-            if (strlen($value) < 50 && count($prioritizedSource) < $maxItems * 0.7) {
+            if (strlen($value) < self::SHORT_STRING_LENGTH && count($prioritizedSource) < $maxItems * self::PRIORITY_RATIO) {
                 $prioritizedSource[$key] = $value;
                 if (isset($targetStrings[$key])) {
                     $prioritizedTarget[$key] = $targetStrings[$key];
@@ -183,7 +190,7 @@ class JSONTranslationContextProvider
         // Priority 2: Add remaining items (excluding very long texts)
         foreach ($sourceStrings as $key => $value) {
             // Skip very long texts (5+ line breaks)
-            if (substr_count($value, "\n") >= 5) {
+            if ($this->isVeryLongText($value)) {
                 continue;
             }
             
@@ -220,11 +227,11 @@ class JSONTranslationContextProvider
         // Exclude very long texts with many line breaks
         foreach ($sourceStrings as $key => $value) {
             // Skip very long texts (5+ line breaks)
-            if (substr_count($value, "\n") >= 5) {
+            if ($this->isVeryLongText($value)) {
                 continue;
             }
             
-            if (strlen($value) < 50 && count($prioritized) < $maxItems * 0.7) {
+            if (strlen($value) < self::SHORT_STRING_LENGTH && count($prioritized) < $maxItems * self::PRIORITY_RATIO) {
                 $prioritized[$key] = $value;
             }
         }
@@ -232,7 +239,7 @@ class JSONTranslationContextProvider
         // Priority 2: Add remaining items (excluding very long texts)
         foreach ($sourceStrings as $key => $value) {
             // Skip very long texts (5+ line breaks)
-            if (substr_count($value, "\n") >= 5) {
+            if ($this->isVeryLongText($value)) {
                 continue;
             }
             
@@ -258,5 +265,16 @@ class JSONTranslationContextProvider
     protected function getLanguageDirectory(string $baseDirectory, string $locale): string
     {
         return $baseDirectory . '/' . $locale;
+    }
+
+    /**
+     * Check if text is very long (has too many line breaks)
+     * 
+     * @param string $text The text to check
+     * @return bool True if the text is considered very long
+     */
+    protected function isVeryLongText(string $text): bool
+    {
+        return substr_count($text, "\n") >= self::MAX_LINE_BREAKS;
     }
 }

--- a/src/AI/JSONTranslationContextProvider.php
+++ b/src/AI/JSONTranslationContextProvider.php
@@ -273,8 +273,12 @@ class JSONTranslationContextProvider
      * @param string $text The text to check
      * @return bool True if the text is considered very long
      */
-    protected function isVeryLongText(string $text): bool
+    protected function isVeryLongText(?string $text): bool
     {
+        if (is_null($text)) {
+            return false;
+        }
+
         return substr_count($text, "\n") >= self::MAX_LINE_BREAKS;
     }
 }

--- a/src/Console/TranslateCrowdinParallel.php
+++ b/src/Console/TranslateCrowdinParallel.php
@@ -112,6 +112,8 @@ class TranslateCrowdinParallel extends TranslateCrowdin
     ): array {
         $cmd = [
             'php',
+            '-d',
+            'memory_limit=2G',
             'artisan',
             'ai-translator:translate-crowdin',
             '--token='.$token,

--- a/src/Console/TranslateJsonStructured.php
+++ b/src/Console/TranslateJsonStructured.php
@@ -35,7 +35,9 @@ class TranslateJsonStructured extends Command
      * Constants for magic numbers
      */
     protected const MAX_LINE_BREAKS = 5;
+
     protected const SHORT_STRING_LENGTH = 50;
+
     protected const PRIORITY_RATIO = 0.7;
 
     /**
@@ -289,13 +291,13 @@ class TranslateJsonStructured extends Command
                 // Calculate relative path from source directory
                 $sourceBaseDir = $this->sourceDirectory.'/'.$this->sourceLocale;
                 $relativePath = str_replace($sourceBaseDir.'/', '', $file);
-                
+
                 // Target file path (maintaining directory structure)
                 $outputFile = $this->getOutputDirectoryLocale($locale).'/'.$relativePath;
-                
+
                 // Create output directory if it doesn't exist
                 $outputDir = dirname($outputFile);
-                if (!is_dir($outputDir)) {
+                if (! is_dir($outputDir)) {
                     mkdir($outputDir, 0755, true);
                 }
 
@@ -324,13 +326,14 @@ class TranslateJsonStructured extends Command
                         if ($targetStringTransformer->isTranslated($key)) {
                             return false;
                         }
-                        
+
                         // Skip very long texts (5+ line breaks)
                         if ($this->isVeryLongText($value)) {
                             $this->line($this->colors['gray']."    ⏩ Skipping very long text: {$key}".$this->colors['reset']);
+
                             return false;
                         }
-                        
+
                         return true;
                     })
                     ->toArray();
@@ -445,7 +448,7 @@ class TranslateJsonStructured extends Command
         // Remove source directory path to display relative path
         $sourceBaseDir = $this->sourceDirectory.'/'.$this->sourceLocale;
         $relativeFile = str_replace($sourceBaseDir.'/', '', $sourceFile);
-        
+
         $this->line("\n".$this->colors['purple_bg'].$this->colors['white'].$this->colors['bold'].' File Translation '.$this->colors['reset']);
         $this->line($this->colors['yellow'].'  File: '.
             $this->colors['reset'].$this->colors['bold'].$relativeFile.
@@ -727,7 +730,7 @@ class TranslateJsonStructured extends Command
         $directories = array_diff(scandir($root), ['.', '..']);
         // Filter only directories and exclude those starting with _
         $directories = array_filter($directories, function ($directory) use ($root) {
-            return is_dir($root.'/'.$directory) && !str_starts_with($directory, '_');
+            return is_dir($root.'/'.$directory) && ! str_starts_with($directory, '_');
         });
 
         return collect($directories)->values()->toArray();
@@ -747,36 +750,36 @@ class TranslateJsonStructured extends Command
     public function getStringFilePaths(string $locale): array
     {
         $root = $this->sourceDirectory.'/'.$locale;
-        
-        if (!is_dir($root)) {
+
+        if (! is_dir($root)) {
             return [];
         }
-        
+
         return $this->getAllJsonFiles($root);
     }
-    
+
     /**
      * Recursively find all JSON files in a directory
      */
     protected function getAllJsonFiles(string $directory): array
     {
         $files = [];
-        
-        if (!is_dir($directory)) {
+
+        if (! is_dir($directory)) {
             return [];
         }
-        
+
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS),
             RecursiveIteratorIterator::SELF_FIRST
         );
-        
+
         foreach ($iterator as $file) {
             if ($file->isFile() && $file->getExtension() === 'json') {
                 $files[] = $file->getPathname();
             }
         }
-        
+
         return $files;
     }
 
@@ -806,12 +809,16 @@ class TranslateJsonStructured extends Command
 
     /**
      * Check if text is very long (has too many line breaks)
-     * 
-     * @param string $text The text to check
+     *
+     * @param  string|null  $text  The text to check
      * @return bool True if the text is considered very long
      */
-    protected function isVeryLongText(string $text): bool
+    protected function isVeryLongText(?string $text): bool
     {
+        if (is_null($text)) {
+            return false;
+        }
+
         return substr_count($text, "\n") >= self::MAX_LINE_BREAKS;
     }
 }

--- a/src/Console/TranslateJsonStructured.php
+++ b/src/Console/TranslateJsonStructured.php
@@ -1,0 +1,799 @@
+<?php
+
+namespace Kargnas\LaravelAiTranslator\Console;
+
+use Illuminate\Console\Command;
+use Kargnas\LaravelAiTranslator\AI\AIProvider;
+use Kargnas\LaravelAiTranslator\AI\JSONTranslationContextProvider;
+use Kargnas\LaravelAiTranslator\AI\Language\LanguageConfig;
+use Kargnas\LaravelAiTranslator\AI\Printer\TokenUsagePrinter;
+use Kargnas\LaravelAiTranslator\Enums\PromptType;
+use Kargnas\LaravelAiTranslator\Enums\TranslationStatus;
+use Kargnas\LaravelAiTranslator\Transformers\JSONLangTransformer;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Artisan command that translates JSON language files with nested directory structure using LLMs
+ * with support for multiple locales, reference languages, chunking for large files, and customizable context settings
+ */
+class TranslateJsonStructured extends Command
+{
+    protected $signature = 'ai-translator:translate-json-structured
+        {--s|source= : Source language to translate from (e.g. --source=en)}
+        {--l|locale=* : Target locales to translate (e.g. --locale=ko,ja). If not provided, will ask interactively}
+        {--r|reference= : Reference languages for translation guidance (e.g. --reference=fr,es). If not provided, will ask interactively}
+        {--c|chunk= : Chunk size for translation (e.g. --chunk=100)}
+        {--m|max-context= : Maximum number of context items to include (e.g. --max-context=1000)}
+        {--force-big-files : Force translation of files with more than 500 strings}
+        {--show-prompt : Show the whole AI prompts during translation}
+        {--non-interactive : Run in non-interactive mode, using default or provided values}';
+
+    protected $description = 'Translates JSON language files with nested directory structure using LLMs with support for multiple locales, reference languages, chunking for large files, and customizable context settings';
+
+    /**
+     * Translation settings
+     */
+    protected string $sourceLocale;
+
+    protected string $sourceDirectory;
+
+    protected int $chunkSize;
+
+    protected array $referenceLocales = [];
+
+    protected int $defaultChunkSize = 100;
+
+    protected int $defaultMaxContextItems = 1000;
+
+    protected int $warningStringCount = 500;
+
+    /**
+     * Token usage tracking
+     */
+    protected array $tokenUsage = [
+        'input_tokens' => 0,
+        'output_tokens' => 0,
+        'total_tokens' => 0,
+    ];
+
+    /**
+     * Color codes
+     */
+    protected array $colors = [
+        'reset' => "\033[0m",
+        'red' => "\033[31m",
+        'green' => "\033[32m",
+        'yellow' => "\033[33m",
+        'blue' => "\033[34m",
+        'purple' => "\033[35m",
+        'cyan' => "\033[36m",
+        'white' => "\033[37m",
+        'gray' => "\033[90m",
+        'bold' => "\033[1m",
+        'underline' => "\033[4m",
+        'red_bg' => "\033[41m",
+        'green_bg' => "\033[42m",
+        'yellow_bg' => "\033[43m",
+        'blue_bg' => "\033[44m",
+        'purple_bg' => "\033[45m",
+        'cyan_bg' => "\033[46m",
+        'white_bg' => "\033[47m",
+    ];
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $sourceDirectory = config('ai-translator.source_directory');
+        $sourceLocale = config('ai-translator.source_locale');
+
+        $this->setDescription(
+            "Translates JSON language files with nested directory structure using AI technology\n".
+            "  Source Directory: {$sourceDirectory}\n".
+            "  Default Source Locale: {$sourceLocale}"
+        );
+    }
+
+    /**
+     * Main command execution method
+     */
+    public function handle()
+    {
+        // Display header
+        $this->displayHeader();
+
+        // Set source directory
+        $this->sourceDirectory = config('ai-translator.source_directory');
+
+        // Check if running in non-interactive mode
+        $nonInteractive = $this->option('non-interactive');
+
+        // Select source language
+        if ($nonInteractive || $this->option('source')) {
+            $this->sourceLocale = $this->option('source') ?? config('ai-translator.source_locale', 'en');
+            $this->info($this->colors['green'].'✓ Selected source locale: '.
+                $this->colors['reset'].$this->colors['bold'].$this->sourceLocale.
+                $this->colors['reset']);
+        } else {
+            $this->sourceLocale = $this->choiceLanguages(
+                $this->colors['yellow'].'Choose a source language to translate from'.$this->colors['reset'],
+                false,
+                'en'
+            );
+        }
+
+        // Select reference languages
+        if ($nonInteractive) {
+            $this->referenceLocales = $this->option('reference')
+                ? explode(',', (string) $this->option('reference'))
+                : [];
+            if (! empty($this->referenceLocales)) {
+                $this->info($this->colors['green'].'✓ Selected reference locales: '.
+                    $this->colors['reset'].$this->colors['bold'].implode(', ', $this->referenceLocales).
+                    $this->colors['reset']);
+            }
+        } elseif ($this->option('reference')) {
+            $this->referenceLocales = explode(',', $this->option('reference'));
+            $this->info($this->colors['green'].'✓ Selected reference locales: '.
+                $this->colors['reset'].$this->colors['bold'].implode(', ', $this->referenceLocales).
+                $this->colors['reset']);
+        } elseif ($this->ask($this->colors['yellow'].'Do you want to add reference languages? (y/n)'.$this->colors['reset'], 'n') === 'y') {
+            $this->referenceLocales = $this->choiceLanguages(
+                $this->colors['yellow']."Choose reference languages for translation guidance. Select languages with high-quality translations. Multiple selections with comma separator (e.g. '1,2')".$this->colors['reset'],
+                true
+            );
+        }
+
+        // Set chunk size
+        if ($nonInteractive || $this->option('chunk')) {
+            $this->chunkSize = (int) ($this->option('chunk') ?? $this->defaultChunkSize);
+            $this->info($this->colors['green'].'✓ Chunk size: '.
+                $this->colors['reset'].$this->colors['bold'].$this->chunkSize.
+                $this->colors['reset']);
+        } else {
+            $this->chunkSize = (int) $this->ask(
+                $this->colors['yellow'].'Enter the chunk size for translation. Translate strings in a batch. The higher, the cheaper.'.$this->colors['reset'],
+                $this->defaultChunkSize
+            );
+        }
+
+        // Set context items count
+        if ($nonInteractive || $this->option('max-context')) {
+            $maxContextItems = (int) ($this->option('max-context') ?? $this->defaultMaxContextItems);
+            $this->info($this->colors['green'].'✓ Maximum context items: '.
+                $this->colors['reset'].$this->colors['bold'].$maxContextItems.
+                $this->colors['reset']);
+        } else {
+            $maxContextItems = (int) $this->ask(
+                $this->colors['yellow'].'Maximum number of context items to include for consistency (set 0 to disable)'.$this->colors['reset'],
+                $this->defaultMaxContextItems
+            );
+        }
+
+        // Execute translation
+        $this->translate($maxContextItems);
+
+        return 0;
+    }
+
+    /**
+     * 헤더 출력
+     */
+    protected function displayHeader(): void
+    {
+        $this->line("\n".$this->colors['blue_bg'].$this->colors['white'].$this->colors['bold'].' Laravel AI Translator - JSON Structured Files '.$this->colors['reset']);
+        $this->line($this->colors['gray'].'Translating JSON language files with nested directory structure using AI technology'.$this->colors['reset']);
+        $this->line(str_repeat('─', 80)."\n");
+    }
+
+    /**
+     * 언어 선택 헬퍼 메서드
+     *
+     * @param  string  $question  질문
+     * @param  bool  $multiple  다중 선택 여부
+     * @param  string|null  $default  기본값
+     * @return array|string 선택된 언어(들)
+     */
+    public function choiceLanguages(string $question, bool $multiple, ?string $default = null): array|string
+    {
+        $locales = $this->getExistingLocales();
+
+        $selectedLocales = $this->choice(
+            $question,
+            $locales,
+            $default,
+            3,
+            $multiple
+        );
+
+        if (is_array($selectedLocales)) {
+            $this->info($this->colors['green'].'✓ Selected locales: '.
+                $this->colors['reset'].$this->colors['bold'].implode(', ', $selectedLocales).
+                $this->colors['reset']);
+        } else {
+            $this->info($this->colors['green'].'✓ Selected locale: '.
+                $this->colors['reset'].$this->colors['bold'].$selectedLocales.
+                $this->colors['reset']);
+        }
+
+        return $selectedLocales;
+    }
+
+    /**
+     * Execute translation
+     *
+     * @param  int  $maxContextItems  Maximum number of context items
+     */
+    public function translate(int $maxContextItems = 100): void
+    {
+        // 커맨드라인에서 지정된 로케일 가져오기
+        $specifiedLocales = $this->option('locale');
+
+        // 사용 가능한 모든 로케일 가져오기
+        $availableLocales = $this->getExistingLocales();
+
+        // 지정된 로케일이 있으면 검증하고 사용, 없으면 모든 로케일 사용
+        $locales = ! empty($specifiedLocales)
+            ? $this->validateAndFilterLocales($specifiedLocales, $availableLocales)
+            : $availableLocales;
+
+        if (empty($locales)) {
+            $this->error('No valid locales specified or found for translation.');
+
+            return;
+        }
+
+        $fileCount = 0;
+        $totalStringCount = 0;
+        $totalTranslatedCount = 0;
+
+        foreach ($locales as $locale) {
+            // 소스 언어와 같거나 스킵 목록에 있는 언어는 건너뜀
+            if ($locale === $this->sourceLocale || in_array($locale, config('ai-translator.skip_locales', []))) {
+                $this->warn('Skipping locale '.$locale.'.');
+
+                continue;
+            }
+
+            $targetLanguageName = LanguageConfig::getLanguageName($locale);
+
+            if (! $targetLanguageName) {
+                $this->error("Language name not found for locale: {$locale}. Please add it to the config file.");
+
+                continue;
+            }
+
+            $this->line(str_repeat('─', 80));
+            $this->line(str_repeat('─', 80));
+            $this->line("\n".$this->colors['blue_bg'].$this->colors['white'].$this->colors['bold']." Starting {$targetLanguageName} ({$locale}) ".$this->colors['reset']);
+
+            $localeFileCount = 0;
+            $localeStringCount = 0;
+            $localeTranslatedCount = 0;
+
+            // 소스 파일 목록 가져오기
+            $files = $this->getStringFilePaths($this->sourceLocale);
+
+            foreach ($files as $file) {
+                // 소스 디렉토리에서의 상대 경로 계산
+                $sourceBaseDir = $this->sourceDirectory.'/'.$this->sourceLocale;
+                $relativePath = str_replace($sourceBaseDir.'/', '', $file);
+                
+                // 타겟 파일 경로 (디렉토리 구조 유지)
+                $outputFile = $this->getOutputDirectoryLocale($locale).'/'.$relativePath;
+                
+                // 출력 디렉토리가 없으면 생성
+                $outputDir = dirname($outputFile);
+                if (!is_dir($outputDir)) {
+                    mkdir($outputDir, 0755, true);
+                }
+
+                if (in_array(basename($file), config('ai-translator.skip_files', []))) {
+                    $this->warn('Skipping file  '.basename($file).'.');
+
+                    continue;
+                }
+
+                $this->displayFileInfo($file, $locale, $outputFile);
+
+                $localeFileCount++;
+                $fileCount++;
+
+                // Load source strings
+                $transformer = new JSONLangTransformer($file);
+                $sourceStringList = $transformer->flatten();
+
+                // Load target strings (or create)
+                $targetStringTransformer = new JSONLangTransformer($outputFile);
+
+                // Filter untranslated strings only and skip very long texts
+                $sourceStringList = collect($sourceStringList)
+                    ->filter(function ($value, $key) use ($targetStringTransformer) {
+                        // Skip already translated ones
+                        if ($targetStringTransformer->isTranslated($key)) {
+                            return false;
+                        }
+                        
+                        // Skip very long texts (5+ line breaks)
+                        if (substr_count($value, "\n") >= 5) {
+                            $this->line($this->colors['gray']."    ⏩ Skipping very long text: {$key}".$this->colors['reset']);
+                            return false;
+                        }
+                        
+                        return true;
+                    })
+                    ->toArray();
+
+                // Skip if no items to translate
+                if (count($sourceStringList) === 0) {
+                    $this->info($this->colors['green'].'  ✓ '.$this->colors['reset'].'All strings are already translated. Skipping.');
+
+                    continue;
+                }
+
+                $localeStringCount += count($sourceStringList);
+                $totalStringCount += count($sourceStringList);
+
+                // Check if there are many strings to translate
+                if (count($sourceStringList) > $this->warningStringCount && ! $this->option('force-big-files')) {
+                    if (
+                        ! $this->confirm(
+                            $this->colors['yellow'].'⚠️ Warning: '.$this->colors['reset'].
+                            'File has '.count($sourceStringList).' strings to translate. This could be expensive. Continue?',
+                            true
+                        )
+                    ) {
+                        $this->warn('Translation stopped by user.');
+
+                        return;
+                    }
+                }
+
+                // Load reference translations (from all files)
+                $referenceStringList = $this->loadReferenceTranslations($file, $locale, $sourceStringList);
+
+                // Process in chunks
+                $chunkCount = 0;
+                $totalChunks = ceil(count($sourceStringList) / $this->chunkSize);
+
+                collect($sourceStringList)
+                    ->chunk($this->chunkSize)
+                    ->each(function ($chunk) use ($locale, $file, $targetStringTransformer, $referenceStringList, $maxContextItems, &$localeTranslatedCount, &$totalTranslatedCount, &$chunkCount, $totalChunks) {
+                        $chunkCount++;
+                        $this->info($this->colors['yellow'].'  ⏺ Processing chunk '.
+                            $this->colors['reset']."{$chunkCount}/{$totalChunks}".
+                            $this->colors['gray'].' ('.$chunk->count().' strings)'.
+                            $this->colors['reset']);
+
+                        // Get global translation context
+                        $globalContext = $this->getGlobalContext($file, $locale, $maxContextItems);
+
+                        // Configure translator
+                        $translator = $this->setupTranslator(
+                            $file,
+                            $chunk,
+                            $referenceStringList,
+                            $locale,
+                            $globalContext
+                        );
+
+                        try {
+                            // Execute translation
+                            $translatedItems = $translator->translate();
+                            $localeTranslatedCount += count($translatedItems);
+                            $totalTranslatedCount += count($translatedItems);
+
+                            // Save translation results - display is handled by onTranslated
+                            foreach ($translatedItems as $item) {
+                                $targetStringTransformer->updateString($item->key, $item->translated);
+                            }
+
+                            // Display number of saved items
+                            $this->info($this->colors['green'].'  ✓ '.$this->colors['reset']."{$localeTranslatedCount} strings saved.");
+
+                            // Calculate and display cost
+                            $this->displayCostEstimation($translator);
+
+                            // Accumulate token usage
+                            $usage = $translator->getTokenUsage();
+                            $this->updateTokenUsageTotals($usage);
+
+                        } catch (\Exception $e) {
+                            $this->error('Translation failed: '.$e->getMessage());
+                        }
+                    });
+            }
+
+            // Display translation summary for each language
+            $this->displayTranslationSummary($locale, $localeFileCount, $localeStringCount, $localeTranslatedCount);
+        }
+
+        // All translations completed message
+        $this->line("\n".$this->colors['green_bg'].$this->colors['white'].$this->colors['bold'].' All translations completed '.$this->colors['reset']);
+        $this->line($this->colors['yellow'].'Total files processed: '.$this->colors['reset'].$fileCount);
+        $this->line($this->colors['yellow'].'Total strings found: '.$this->colors['reset'].$totalStringCount);
+        $this->line($this->colors['yellow'].'Total strings translated: '.$this->colors['reset'].$totalTranslatedCount);
+    }
+
+    /**
+     * 비용 계산 및 표시
+     */
+    protected function displayCostEstimation(AIProvider $translator): void
+    {
+        $usage = $translator->getTokenUsage();
+        $printer = new TokenUsagePrinter($translator->getModel());
+        $printer->printTokenUsageSummary($this, $usage);
+        $printer->printCostEstimation($this, $usage);
+    }
+
+    /**
+     * 파일 정보 표시
+     */
+    protected function displayFileInfo(string $sourceFile, string $locale, string $outputFile): void
+    {
+        // 상대 경로 표시를 위해 소스 디렉토리 경로 제거
+        $sourceBaseDir = $this->sourceDirectory.'/'.$this->sourceLocale;
+        $relativeFile = str_replace($sourceBaseDir.'/', '', $sourceFile);
+        
+        $this->line("\n".$this->colors['purple_bg'].$this->colors['white'].$this->colors['bold'].' File Translation '.$this->colors['reset']);
+        $this->line($this->colors['yellow'].'  File: '.
+            $this->colors['reset'].$this->colors['bold'].$relativeFile.
+            $this->colors['reset']);
+        $this->line($this->colors['yellow'].'  Language: '.
+            $this->colors['reset'].$this->colors['bold'].$locale.
+            $this->colors['reset']);
+        $this->line($this->colors['gray'].'  Source: '.$sourceFile.$this->colors['reset']);
+        $this->line($this->colors['gray'].'  Target: '.$outputFile.$this->colors['reset']);
+    }
+
+    /**
+     * Display translation completion summary
+     */
+    protected function displayTranslationSummary(string $locale, int $fileCount, int $stringCount, int $translatedCount): void
+    {
+        $this->line("\n".str_repeat('─', 80));
+        $this->line($this->colors['green_bg'].$this->colors['white'].$this->colors['bold']." Translation Complete: {$locale} ".$this->colors['reset']);
+        $this->line($this->colors['yellow'].'Files processed: '.$this->colors['reset'].$fileCount);
+        $this->line($this->colors['yellow'].'Strings found: '.$this->colors['reset'].$stringCount);
+        $this->line($this->colors['yellow'].'Strings translated: '.$this->colors['reset'].$translatedCount);
+
+        // Display accumulated token usage
+        if ($this->tokenUsage['total_tokens'] > 0) {
+            $this->line("\n".$this->colors['blue_bg'].$this->colors['white'].$this->colors['bold'].' Total Token Usage '.$this->colors['reset']);
+            $this->line($this->colors['yellow'].'Input Tokens: '.$this->colors['reset'].$this->colors['green'].$this->tokenUsage['input_tokens'].$this->colors['reset']);
+            $this->line($this->colors['yellow'].'Output Tokens: '.$this->colors['reset'].$this->colors['green'].$this->tokenUsage['output_tokens'].$this->colors['reset']);
+            $this->line($this->colors['yellow'].'Total Tokens: '.$this->colors['reset'].$this->colors['bold'].$this->colors['purple'].$this->tokenUsage['total_tokens'].$this->colors['reset']);
+        }
+    }
+
+    /**
+     * Load reference translations (from all files)
+     */
+    protected function loadReferenceTranslations(string $file, string $targetLocale, array $sourceStringList): array
+    {
+        // 타겟 언어와 레퍼런스 언어들을 모두 포함
+        $allReferenceLocales = array_merge([$targetLocale], $this->referenceLocales);
+        $langDirectory = config('ai-translator.source_directory');
+        $currentFileName = basename($file);
+
+        return collect($allReferenceLocales)
+            ->filter(fn ($referenceLocale) => $referenceLocale !== $this->sourceLocale)
+            ->map(function ($referenceLocale) use ($currentFileName) {
+                $referenceLocaleDir = $this->getOutputDirectoryLocale($referenceLocale);
+
+                if (! is_dir($referenceLocaleDir)) {
+                    $this->line($this->colors['gray']."    ℹ Reference directory not found: {$referenceLocale}".$this->colors['reset']);
+
+                    return null;
+                }
+
+                // 해당 로케일 디렉토리의 모든 JSON 파일 재귀적으로 가져오기
+                $referenceFiles = $this->getAllJsonFiles($referenceLocaleDir);
+
+                if (empty($referenceFiles)) {
+                    $this->line($this->colors['gray']."    ℹ Reference file not found: {$referenceLocale}".$this->colors['reset']);
+
+                    return null;
+                }
+
+                $this->line($this->colors['blue'].'    ℹ Loading reference: '.
+                    $this->colors['reset']."{$referenceLocale} - ".count($referenceFiles).' files');
+
+                // 유사한 이름의 파일을 먼저 처리하여 컨텍스트 관련성 향상
+                usort($referenceFiles, function ($a, $b) use ($currentFileName) {
+                    $similarityA = similar_text($currentFileName, basename($a));
+                    $similarityB = similar_text($currentFileName, basename($b));
+
+                    return $similarityB <=> $similarityA;
+                });
+
+                $allReferenceStrings = [];
+                $processedFiles = 0;
+
+                foreach ($referenceFiles as $referenceFile) {
+                    try {
+                        $referenceTransformer = new JSONLangTransformer($referenceFile);
+                        $referenceStringList = $referenceTransformer->flatten();
+
+                        if (empty($referenceStringList)) {
+                            continue;
+                        }
+
+                        // 우선순위 적용 (필요한 경우)
+                        if (count($referenceStringList) > 50) {
+                            $referenceStringList = $this->getPrioritizedReferenceStrings($referenceStringList, 50);
+                        }
+
+                        $allReferenceStrings = array_merge($allReferenceStrings, $referenceStringList);
+                        $processedFiles++;
+                    } catch (\Exception $e) {
+                        $this->line($this->colors['gray'].'    ⚠ Reference file loading failed: '.basename($referenceFile).$this->colors['reset']);
+
+                        continue;
+                    }
+                }
+
+                if (empty($allReferenceStrings)) {
+                    return null;
+                }
+
+                return [
+                    'locale' => $referenceLocale,
+                    'strings' => $allReferenceStrings,
+                ];
+            })
+            ->filter()
+            ->values()
+            ->toArray();
+    }
+
+    /**
+     * 레퍼런스 문자열에 우선순위 적용
+     */
+    protected function getPrioritizedReferenceStrings(array $strings, int $maxItems): array
+    {
+        $prioritized = [];
+
+        // 1. 짧은 문자열 우선 (UI 요소, 버튼 등)
+        foreach ($strings as $key => $value) {
+            if (strlen($value) < 50 && count($prioritized) < $maxItems * 0.7) {
+                $prioritized[$key] = $value;
+            }
+        }
+
+        // 2. 나머지 항목 추가
+        foreach ($strings as $key => $value) {
+            if (! isset($prioritized[$key]) && count($prioritized) < $maxItems) {
+                $prioritized[$key] = $value;
+            }
+
+            if (count($prioritized) >= $maxItems) {
+                break;
+            }
+        }
+
+        return $prioritized;
+    }
+
+    /**
+     * Get global translation context
+     */
+    protected function getGlobalContext(string $file, string $locale, int $maxContextItems): array
+    {
+        if ($maxContextItems <= 0) {
+            return [];
+        }
+
+        $contextProvider = new JSONTranslationContextProvider;
+        $globalContext = $contextProvider->getGlobalTranslationContext(
+            $this->sourceLocale,
+            $locale,
+            $file,
+            $maxContextItems
+        );
+
+        if (! empty($globalContext)) {
+            $contextItemCount = collect($globalContext)->map(fn ($items) => count($items['source'] ?? []))->sum();
+            $this->info($this->colors['blue'].'    ℹ Using global context: '.
+                $this->colors['reset'].count($globalContext).' files, '.
+                $contextItemCount.' items');
+        } else {
+            $this->line($this->colors['gray'].'    ℹ No global context available'.$this->colors['reset']);
+        }
+
+        return $globalContext;
+    }
+
+    /**
+     * Setup translator
+     */
+    protected function setupTranslator(
+        string $file,
+        \Illuminate\Support\Collection $chunk,
+        array $referenceStringList,
+        string $locale,
+        array $globalContext
+    ): AIProvider {
+        // 파일 정보 표시 제거 (이미 translate() 메서드에서 처리됨)
+
+        // 레퍼런스 정보를 적절한 형식으로 변환
+        $references = [];
+        foreach ($referenceStringList as $reference) {
+            $referenceLocale = $reference['locale'];
+            $referenceStrings = $reference['strings'];
+            $references[$referenceLocale] = $referenceStrings;
+        }
+
+        // AIProvider 인스턴스 생성
+        $translator = new AIProvider(
+            $file,
+            $chunk->toArray(),
+            $this->sourceLocale,
+            $locale,
+            $references,
+            [],  // additionalRules
+            $globalContext  // globalTranslationContext
+        );
+
+        $translator->setOnThinking(function ($thinking) {
+            echo $this->colors['gray'].$thinking.$this->colors['reset'];
+        });
+
+        $translator->setOnThinkingStart(function () {
+            $this->line($this->colors['gray'].'    '.'🧠 AI Thinking...'.$this->colors['reset']);
+        });
+
+        $translator->setOnThinkingEnd(function () {
+            $this->line($this->colors['gray'].'    '.'Thinking completed.'.$this->colors['reset']);
+        });
+
+        // Set callback for displaying translation progress
+        $translator->setOnTranslated(function ($item, $status, $translatedItems) use ($chunk) {
+            if ($status === TranslationStatus::COMPLETED) {
+                $totalCount = $chunk->count();
+                $completedCount = count($translatedItems);
+
+                $this->line($this->colors['cyan'].'  ⟳ '.
+                    $this->colors['reset'].$item->key.
+                    $this->colors['gray'].' → '.
+                    $this->colors['reset'].$item->translated.
+                    $this->colors['gray']." ({$completedCount}/{$totalCount})".
+                    $this->colors['reset']);
+            }
+        });
+
+        // 토큰 사용량 콜백 설정
+        $translator->setOnTokenUsage(function ($usage) {
+            $isFinal = $usage['final'] ?? false;
+            $inputTokens = $usage['input_tokens'] ?? 0;
+            $outputTokens = $usage['output_tokens'] ?? 0;
+            $totalTokens = $usage['total_tokens'] ?? 0;
+
+            // 실시간 토큰 사용량 표시
+            $this->line($this->colors['gray'].'    Tokens: '.
+                'Input='.$this->colors['green'].$inputTokens.$this->colors['gray'].', '.
+                'Output='.$this->colors['green'].$outputTokens.$this->colors['gray'].', '.
+                'Total='.$this->colors['purple'].$totalTokens.$this->colors['gray'].
+                $this->colors['reset']);
+        });
+
+        // 프롬프트 로깅 콜백 설정
+        if ($this->option('show-prompt')) {
+            $translator->setOnPromptGenerated(function ($prompt, PromptType $type) {
+                $typeText = match ($type) {
+                    PromptType::SYSTEM => '🤖 System Prompt',
+                    PromptType::USER => '👤 User Prompt',
+                };
+
+                echo "\n    {$typeText}:\n";
+                echo $this->colors['gray'].'    '.str_replace("\n", $this->colors['reset']."\n    ".$this->colors['gray'], $prompt).$this->colors['reset']."\n";
+            });
+        }
+
+        return $translator;
+    }
+
+    /**
+     * 토큰 사용량 총계 업데이트
+     */
+    protected function updateTokenUsageTotals(array $usage): void
+    {
+        $this->tokenUsage['input_tokens'] += ($usage['input_tokens'] ?? 0);
+        $this->tokenUsage['output_tokens'] += ($usage['output_tokens'] ?? 0);
+        $this->tokenUsage['total_tokens'] =
+            $this->tokenUsage['input_tokens'] +
+            $this->tokenUsage['output_tokens'];
+    }
+
+    /**
+     * 사용 가능한 로케일 목록 가져오기
+     *
+     * @return array|string[]
+     */
+    public function getExistingLocales(): array
+    {
+        $root = $this->sourceDirectory;
+        $directories = array_diff(scandir($root), ['.', '..']);
+        // 디렉토리만 필터링하고 _로 시작하는 디렉토리 제외
+        $directories = array_filter($directories, function ($directory) use ($root) {
+            return is_dir($root.'/'.$directory) && !str_starts_with($directory, '_');
+        });
+
+        return collect($directories)->values()->toArray();
+    }
+
+    /**
+     * 출력 디렉토리 경로 가져오기
+     */
+    public function getOutputDirectoryLocale(string $locale): string
+    {
+        return config('ai-translator.source_directory').'/'.$locale;
+    }
+
+    /**
+     * 문자열 파일 경로 목록 가져오기 (재귀적 JSON 탐색)
+     */
+    public function getStringFilePaths(string $locale): array
+    {
+        $root = $this->sourceDirectory.'/'.$locale;
+        
+        if (!is_dir($root)) {
+            return [];
+        }
+        
+        return $this->getAllJsonFiles($root);
+    }
+    
+    /**
+     * 디렉토리에서 모든 JSON 파일을 재귀적으로 찾기
+     */
+    protected function getAllJsonFiles(string $directory): array
+    {
+        $files = [];
+        
+        if (!is_dir($directory)) {
+            return [];
+        }
+        
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+        
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'json') {
+                $files[] = $file->getPathname();
+            }
+        }
+        
+        return $files;
+    }
+
+    /**
+     * 지정된 로케일 검증 및 필터링
+     */
+    protected function validateAndFilterLocales(array $specifiedLocales, array $availableLocales): array
+    {
+        $validLocales = [];
+        $invalidLocales = [];
+
+        foreach ($specifiedLocales as $locale) {
+            if (in_array($locale, $availableLocales)) {
+                $validLocales[] = $locale;
+            } else {
+                $invalidLocales[] = $locale;
+            }
+        }
+
+        if (! empty($invalidLocales)) {
+            $this->warn('The following locales are invalid or not available: '.implode(', ', $invalidLocales));
+            $this->info('Available locales: '.implode(', ', $availableLocales));
+        }
+
+        return $validLocales;
+    }
+}

--- a/src/Console/TranslateJsonStructuredParallel.php
+++ b/src/Console/TranslateJsonStructuredParallel.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Kargnas\LaravelAiTranslator\Console;
+
+use Symfony\Component\Process\Process;
+
+class TranslateJsonStructuredParallel extends TranslateJsonStructured
+{
+    protected $signature = 'ai-translator:translate-json-structured-parallel'
+        .' {--locale=* : Target language code(s) (e.g., ko, ja, zh-CN). Multiple locales can be specified}'
+        .' {--chunk-size=50 : Chunk size for translation}'
+        .' {--max-context=100 : Maximum number of context items}'
+        .' {--force-big-files : Skip confirmation for files with many strings}'
+        .' {--max-processes=5 : Number of languages to translate simultaneously}'
+        .' {--show-prompt : Show AI prompts during translation}';
+
+    protected $description = 'Translate JSON files with nested directory structures to multiple languages in parallel';
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $this->displayHeader();
+
+        // Initialize source directory from config
+        $this->sourceDirectory = config('ai-translator.source_directory');
+        $this->sourceLocale = config('ai-translator.source_locale', 'en');
+
+        // Get specified locales or use all available
+        $specifiedLocales = $this->option('locale');
+        $availableLocales = $this->getExistingLocales();
+
+        // Validate and filter locales
+        $locales = ! empty($specifiedLocales)
+            ? $this->validateAndFilterLocales($specifiedLocales, $availableLocales)
+            : $availableLocales;
+
+        // Filter out source locale and skip locales
+        $locales = array_filter($locales, function ($locale) {
+            return $locale !== $this->sourceLocale && ! in_array($locale, config('ai-translator.skip_locales', []));
+        });
+
+        if (empty($locales)) {
+            $this->error('No valid locales found for translation.');
+            return 1;
+        }
+
+        $this->line($this->colors['blue_bg'].$this->colors['white'].$this->colors['bold'].' Starting Parallel Translation '.$this->colors['reset']);
+        $this->line($this->colors['yellow'].'Source locale: '.$this->colors['reset'].$this->colors['bold'].$this->sourceLocale.$this->colors['reset']);
+        $this->line($this->colors['yellow'].'Target locales: '.$this->colors['reset'].$this->colors['bold'].implode(', ', $locales).$this->colors['reset']);
+        $this->line('');
+
+        $maxProcesses = (int) ($this->option('max-processes') ?? 5);
+        $queue = $locales;
+        $running = [];
+        $completed = [];
+        $failed = [];
+
+        while (! empty($queue) || ! empty($running)) {
+            // Start new processes if under limit
+            while (count($running) < $maxProcesses && ! empty($queue)) {
+                $locale = array_shift($queue);
+                $process = new Process(
+                    $this->buildLanguageCommand($locale),
+                    base_path()
+                );
+                $process->setTimeout(null);
+                $process->start(function ($type, $buffer) use ($locale) {
+                    // Display output in real-time if verbose
+                    if ($this->output->isVerbose()) {
+                        $this->output->write("[{$locale}] {$buffer}");
+                    }
+                });
+                $running[$locale] = $process;
+                $this->info($this->colors['blue'].'▶ Started translation for '.$this->colors['reset'].$this->colors['bold'].$locale.$this->colors['reset']);
+            }
+
+            // Check running processes
+            foreach ($running as $locale => $process) {
+                if (! $process->isRunning()) {
+                    // Process completed
+                    $output = $process->getOutput();
+                    $error = $process->getErrorOutput();
+                    
+                    if ($process->isSuccessful()) {
+                        $completed[] = $locale;
+                        $this->info($this->colors['green'].'✓ Completed translation for '.$this->colors['reset'].$this->colors['bold'].$locale.$this->colors['reset']);
+                        
+                        // Show output if verbose
+                        if ($this->output->isVerbose()) {
+                            $this->line($output);
+                        }
+                    } else {
+                        $failed[] = $locale;
+                        $this->error('✗ Failed translation for '.$locale);
+                        if ($error) {
+                            $this->error('Error: '.$error);
+                        }
+                        if ($output) {
+                            $this->error('Output: '.$output);
+                        }
+                    }
+                    
+                    unset($running[$locale]);
+                }
+            }
+
+            // Small delay to prevent CPU spinning
+            usleep(100000); // 0.1 second
+        }
+
+        // Display final summary
+        $this->line('');
+        $this->line(str_repeat('═', 80));
+        $this->line($this->colors['green_bg'].$this->colors['white'].$this->colors['bold'].' Parallel Translation Complete '.$this->colors['reset']);
+        $this->line('');
+        
+        if (! empty($completed)) {
+            $this->line($this->colors['green'].'✓ Successfully translated: '.$this->colors['reset'].implode(', ', $completed));
+        }
+        
+        if (! empty($failed)) {
+            $this->line($this->colors['red'].'✗ Failed translations: '.$this->colors['reset'].implode(', ', $failed));
+        }
+        
+        $this->line('');
+        $this->line($this->colors['yellow'].'Total locales processed: '.$this->colors['reset'].count($locales));
+        $this->line($this->colors['green'].'Successful: '.$this->colors['reset'].count($completed));
+        $this->line($this->colors['red'].'Failed: '.$this->colors['reset'].count($failed));
+
+        return empty($failed) ? 0 : 1;
+    }
+
+    /**
+     * Build the command for translating a single language
+     */
+    private function buildLanguageCommand(string $locale): array
+    {
+        $cmd = [
+            'php',
+            '-d',
+            'memory_limit=2G',
+            'artisan',
+            'ai-translator:translate-json-structured',
+            '--locale='.$locale,
+            '--chunk='.$this->option('chunk-size'),
+            '--max-context='.$this->option('max-context'),
+        ];
+
+        if ($this->option('force-big-files')) {
+            $cmd[] = '--force-big-files';
+        }
+
+        if ($this->option('show-prompt')) {
+            $cmd[] = '--show-prompt';
+        }
+
+        // Add no-interaction flag to prevent prompts in subprocess
+        $cmd[] = '--no-interaction';
+
+        return $cmd;
+    }
+
+    /**
+     * Validate and filter specified locales against available ones
+     */
+    protected function validateAndFilterLocales(array $specifiedLocales, array $availableLocales): array
+    {
+        $validLocales = [];
+        $invalidLocales = [];
+
+        foreach ($specifiedLocales as $locale) {
+            if (in_array($locale, $availableLocales)) {
+                $validLocales[] = $locale;
+            } else {
+                $invalidLocales[] = $locale;
+            }
+        }
+
+        if (! empty($invalidLocales)) {
+            $this->warn('Warning: The following locales are not available and will be skipped: '.implode(', ', $invalidLocales));
+        }
+
+        return $validLocales;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,6 +9,8 @@ use Kargnas\LaravelAiTranslator\Console\TranslateCrowdin;
 use Kargnas\LaravelAiTranslator\Console\TranslateCrowdinParallel;
 use Kargnas\LaravelAiTranslator\Console\TranslateFileCommand;
 use Kargnas\LaravelAiTranslator\Console\TranslateJson;
+use Kargnas\LaravelAiTranslator\Console\TranslateJsonStructured;
+use Kargnas\LaravelAiTranslator\Console\TranslateJsonStructuredParallel;
 use Kargnas\LaravelAiTranslator\Console\TranslateStrings;
 use Kargnas\LaravelAiTranslator\Console\TranslateStringsParallel;
 
@@ -38,6 +40,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             TestTranslateCommand::class,
             TranslateFileCommand::class,
             TranslateJson::class,
+            TranslateJsonStructured::class,
+            TranslateJsonStructuredParallel::class,
         ]);
     }
 }

--- a/src/Transformers/JSONLangTransformer.php
+++ b/src/Transformers/JSONLangTransformer.php
@@ -38,7 +38,8 @@ class JSONLangTransformer
 
         $flattened = $this->flatten();
 
-        return array_key_exists($key, $flattened);
+        // Check if key exists and is not empty string
+        return array_key_exists($key, $flattened) && $flattened[$key] !== '';
     }
 
     public function flatten(): array


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-19 09:57:57 UTC

### Greptile Summary

이 PR은 대규모 JSON 번역 작업을 지원하기 위한 구조화된 병렬 번역 기능을 추가합니다. 주요 변경사항으로는 중첩 디렉토리 구조를 처리하는 `TranslateJsonStructured` 및 `TranslateJsonStructuredParallel` 명령어 추가, JSON 파일용 전용 컨텍스트 제공자(`JSONTranslationContextProvider`) 구현, AI 프롬프트의 XML 구조 전환(CDATA 섹션으로 특수문자 처리 개선), Anthropic 캐시 토큰 추적 추가, 그리고 모든 AI 클라이언트의 타임아웃을 30분으로 확장했습니다. 이 변경들은 기존 PHP 언어 파일 번역 워크플로우와 일관된 패턴을 따르며, 병렬 처리, 청킹, 참조 번역, 토큰 사용량 추적 등 패키지의 핵심 기능을 유지합니다. 새로운 명령어들은 `ServiceProvider`에 등록되어 아티즌 커맨드로 사용할 수 있습니다.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| src/Console/TranslateCrowdinParallel.php | 5/5 | 병렬 프로세스 명령에 2GB 메모리 제한 추가 |
| src/Transformers/JSONLangTransformer.php | 4/5 | `isTranslated` 메서드를 수정하여 빈 문자열을 미번역으로 처리 |
| src/ServiceProvider.php | 5/5 | 두 개의 새로운 JSON 구조화 번역 명령어 등록 |
| src/Console/TranslateJsonStructured.php | 4/5 | 중첩 디렉토리 구조를 지원하는 새로운 JSON 번역 명령어 추가 |
| src/Console/TranslateJsonStructuredParallel.php |3/5 | JSON 구조화 번역의 병렬 실행 명령어 추가 (옵션명 불일치 이슈) |
| src/AI/Clients/OpenAIClient.php | 4/5 | API 타임아웃을 120초에서 1800초(30분)로 증가 |
| src/AI/Clients/AnthropicClient.php | 4/5 | API 타임아웃을 300초에서 1800초(30분)로 증가 |
| config/ai-translator.php | 2/5 | 모델 변경 및 설정 업데이트, 호환성 문제 존재 |
| src/AI/JSONTranslationContextProvider.php | 4/5 | JSON 파일용 글로벌 컨텍스트 제공자 추가 |
| src/AI/AIProvider.php | 4/5 | XML 구조 프롬프트 전환 및 Anthropic 캐시 토큰 추적 추가 |

</details>

### Confidence score: 3/5

- 이 PR은 주의 깊은 검토와 테스트가 필요하며, 여러 잠재적 문제가 있어 즉시 머지하기에는 위험합니다.
- 점수가 낮은 이유: (1) `config/ai-translator.php`에서 `use_extended_thinking`이 호환되지 않는 모델(claude-sonnet-4-20250514)과 함께 활성화됨, (2) `TranslateJsonStructuredParallel.php`의 152번 줄에서 `--chunk` 옵션명이 시그니처의 `--chunk-size`와 불일치, (3) `dot_notation` false 변경이 기존 프로젝트의 하위 호환성에 영향, (4) `AIProvider.php`의 Claude 모델 감지 정규표현식(`preg_match('/^claude.*(3\-7|4)/', ...)`)이 모호하여 의도치 않은 매칭 가능성, (5) 빈 문자열을 미번역으로 처리하는 `JSONLangTransformer` 변경이 의도적으로 빈 값을 사용하는 기존 번역에 영향 가능.
- 특히 주의가 필요한 파일: `config/ai-translator.php`(모델 호환성 확인 필요), `src/Console/TranslateJsonStructuredParallel.php`(옵션명 수정 필요), `src/AI/AIProvider.php`(정규표현식 정밀도 개선 필요).

**PR Description Notes:**
- PR 제목("add feat")이 너무 모호하여 변경사항을 설명하지 못합니다. "Add structured JSON parallel translation feature"와 같이 구체적인 제목이 필요합니다.
- PR body가 null이어서 변경 이유, 테스트 결과, 브레이킹 체인지 등의 정보가 없습니다. 상세한 설명을 추가해야 합니다.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TranslateJsonStructuredParallel
    participant Process
    participant TranslateJsonStructured
    participant AIProvider
    participant AnthropicClient
    participant GeminiClient
    participant OpenAIClient
    participant JSONLangTransformer
    participant JSONTranslationContextProvider

    User->>TranslateJsonStructuredParallel: "Execute ai-translator:translate-json-structured-parallel"
    TranslateJsonStructuredParallel->>TranslateJsonStructuredParallel: "Initialize source directory and locale"
    TranslateJsonStructuredParallel->>TranslateJsonStructuredParallel: "Get and validate target locales"
    TranslateJsonStructuredParallel->>TranslateJsonStructuredParallel: "Filter out source and skip locales"
    
    loop For each locale (parallel, max processes)
        TranslateJsonStructuredParallel->>Process: "buildLanguageCommand(locale)"
        TranslateJsonStructuredParallel->>Process: "Start new translation process"
        Process->>TranslateJsonStructured: "Execute ai-translator:translate-json-structured"
        
        TranslateJsonStructured->>TranslateJsonStructured: "Get source JSON files recursively"
        
        loop For each JSON file
            TranslateJsonStructured->>JSONLangTransformer: "Load source strings and flatten"
            TranslateJsonStructured->>JSONLangTransformer: "Load target strings (if exists)"
            TranslateJsonStructured->>JSONLangTransformer: "Filter untranslated and skip very long texts"
            TranslateJsonStructured->>TranslateJsonStructured: "loadReferenceTranslations()"
            TranslateJsonStructured->>JSONTranslationContextProvider: "getGlobalTranslationContext()"
            JSONTranslationContextProvider->>JSONTranslationContextProvider: "getAllJsonFiles() recursively"
            JSONTranslationContextProvider->>JSONTranslationContextProvider: "getPrioritizedStrings()"
            JSONTranslationContextProvider-->>TranslateJsonStructured: "Return context data"
            
            loop For each chunk
                TranslateJsonStructured->>AIProvider: "Create AIProvider with context"
                TranslateJsonStructured->>AIProvider: "Set callbacks (onTranslated, onThinking, onTokenUsage)"
                TranslateJsonStructured->>AIProvider: "translate()"
                
                alt Provider is Anthropic
                    AIProvider->>AnthropicClient: "messages().createStream()"
                    AnthropicClient->>AnthropicClient: "requestStream() with 30min timeout"
                    AnthropicClient-->>AIProvider: "Stream translation chunks"
                else Provider is OpenAI
                    AIProvider->>OpenAIClient: "createChatStream()"
                    OpenAIClient->>OpenAIClient: "requestStream() with 30min timeout"
                    OpenAIClient-->>AIProvider: "Stream translation chunks"
                else Provider is Gemini
                    AIProvider->>GeminiClient: "request() with 30min timeout"
                    GeminiClient-->>AIProvider: "Return translation"
                end
                
                AIProvider->>AIProvider: "Parse response and verify translations"
                AIProvider-->>TranslateJsonStructured: "Return translated items"
                
                TranslateJsonStructured->>JSONLangTransformer: "updateString() for each translation"
                JSONLangTransformer->>JSONLangTransformer: "saveToFile() with _comment metadata"
            end
        end
        
        Process-->>TranslateJsonStructuredParallel: "Process completed/failed status"
        TranslateJsonStructuredParallel->>TranslateJsonStructuredParallel: "Track completed and failed locales"
    end
    
    TranslateJsonStructuredParallel->>User: "Display final summary with statistics"
```

<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=c7cfc233-3dc9-4144-957d-dfcfb4ae64af))
- Context from `dashboard` - .cursorrules ([source](https://app.greptile.com/review/custom-context?memory=9a8520af-3126-4dd0-b04e-b915016afe40))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=9cdd711d-bd7c-4818-b7b9-22a69703b7e0))
</details>


<!-- /greptile_comment -->