### PR TITLE
Fix PHPStan memory usage and parsing callback

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+ini_set('memory_limit', '512M');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,8 @@ includes:
     - ./vendor/phpstan/phpstan-phpunit/extension.neon
 
 parameters:
+    bootstrapFiles:
+        - phpstan-bootstrap.php
     level: 5
     paths:
         - src

--- a/src/AI/AIProvider.php
+++ b/src/AI/AIProvider.php
@@ -782,11 +782,10 @@ class AIProvider
             }
 
             // Try parsing the entire response
-            $responseParser->parse($responseText);
-            $finalItems = $responseParser->getTranslatedItems();
+            $finalItems = $responseParser->parse($responseText);
 
             // Process last parsed items with callback
-            if (! empty($finalItems) && $this->onTranslated) {
+            if ($this->onTranslated && $finalItems !== []) {
                 foreach ($finalItems as $item) {
                     if (! isset($processedKeys[$item->key])) {
                         $processedKeys[$item->key] = true;


### PR DESCRIPTION
## Summary
- add a PHPStan bootstrap to raise the memory limit during analysis
- reference the bootstrap file from phpstan.neon
- use the parser return value for final callbacks to satisfy PHPStan

## Testing
- `./vendor/bin/phpstan analyse`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f58e59c88321aa586bfb105e8b82)