### PR TITLE
Allow symfony/process ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "guzzlehttp/promises": "^1.0|^2.0",
         "illuminate/support": ">=8.0",
         "openai-php/client": ">=0.2 <1.0",
-        "symfony/process": "^5.0|^6.0|^7.0"
+        "symfony/process": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
## What

Widens the `symfony/process` constraint from `^5.0|^6.0|^7.0` to `^5.0|^6.0|^7.0|^8.0`.

## Why

The `^7.0` cap propagates to every application that installs this package: Composer cannot then install anything requiring `symfony/process ^8`. Pest 5 is one such package, and Laravel 13 already allows `symfony/process ^8.0.5`, so the cap is the only thing standing between the two.

## Compatibility

The package touches only the stable core of the Process API — `new Process(array, cwd)`, `start()`, `getOutput()`, `isRunning()` — in `TranslateStringsParallel` and `TranslateCrowdinParallel`. None of it changed between Symfony 5 and 8, so no code change accompanies the constraint.

resolved #64