### PR TITLE
feat: make OpenRouter the default provider and load live model pricing

### DIFF
--- a/.env.testing.example
+++ b/.env.testing.example
@@ -1,3 +1,4 @@
+OPENROUTER_API_KEY=your-openrouter-api-key-here
 ANTHROPIC_API_KEY=your-anthropic-api-key-here
 OPENAI_API_KEY=your-openai-api-key-here
 GEMINI_API_KEY=your-gemini-api-key-here

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4]
 
     name: PHP ${{ matrix.php }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 ## Code Style Guidelines
 
 ### PHP Standards
-- **Version**: Minimum PHP 8.0, use PHP 8.1+ features where available
+- **Version**: Minimum PHP 8.2
 - **Standards**: Follow PSR-12 coding standard
 - **Testing**: Use Pest for tests, follow existing test patterns
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ AI-powered translation tool for Laravel language files
   - Better handling of backup directories
   - Strict path matching to prevent unintended deletions
 - 🔁 **Parallel Translation**: Translate multiple locales concurrently with the `translate-parallel` command
-- **New Provider**: Added Google Gemini support (including the 2.5 models)
-- **AI Enhancement**: Added support for Claude 3.7's Extended Thinking capabilities
-  - Extended context window up to 200K tokens, output tokens up to 64K tokens
-  - Enhanced reasoning for complex translations
-  - Improved context understanding with extended thinking mode
+- **OpenRouter Provider**: Uses PrismPHP to access current frontier models through one API
+  - Defaults to Claude Opus 5
+  - Supports GPT-5.6 Sol and Gemini 3.1 Pro Preview model IDs
+  - Supports streaming responses and reasoning callbacks
 - **Visual Logging Improvements**: Completely redesigned logging system
   - 🎨 Beautiful color-coded console output
   - 📊 Real-time progress indicators
@@ -60,7 +59,7 @@ Laravel AI Translator is a powerful tool designed to streamline the localization
 Key benefits:
 
 - Time-saving: Translate all your language files with one simple command
-- AI-powered: Utilizes state-of-the-art language models (GPT-4, GPT-4o, GPT-3.5, Claude, Gemini) for superior translation quality
+- AI-powered: Uses current frontier models such as Claude Opus 5, GPT-5.6 Sol, and Gemini 3.1 Pro Preview
 - Smart context understanding: Accurately captures nuances, technical terms, and Laravel-specific expressions
 - Seamless integration: Works within your existing Laravel project structure, preserving complex language file structures
 
@@ -135,8 +134,8 @@ These custom styles offer creative ways to customize your translations, adding a
 
 ## Prerequisites
 
-- PHP 8.0 or higher
-- Laravel 8.0 or higher
+- PHP 8.2 or higher
+- Laravel 11.0 or higher
 
 ## Installation
 
@@ -146,15 +145,13 @@ These custom styles offer creative ways to customize your translations, adding a
    composer require kargnas/laravel-ai-translator
    ```
 
-2. Add the Claude API key to your `.env` file:
+2. Add your OpenRouter API key to `.env`:
 
+   ```env
+   OPENROUTER_API_KEY=your-openrouter-api-key-here
    ```
-   ANTHROPIC_API_KEY=your-anthropic-api-key-here
-   ```
 
-   You can obtain an API key from the [Anthropic Console](https://console.anthropic.com/settings/keys).
-
-(If you want to use OpenAI's GPT or Google's Gemini instead, see step 4 below for configuration instructions.)
+   Create a key in [OpenRouter](https://openrouter.ai/settings/keys).
 
 3. (Optional) Publish the configuration file:
 
@@ -164,40 +161,7 @@ These custom styles offer creative ways to customize your translations, adding a
 
    This step is optional but recommended if you want to customize the package's behavior. It will create a `config/ai-translator.php` file where you can modify various settings.
 
-4. (Optional) The package is configured to use Claude by default. If you want to use OpenAI's GPT or Google's Gemini instead, update the `config/ai-translator.php` file:
-
-   For OpenAI GPT:
-
-   ```php
-   'ai' => [
-       'provider' => 'openai',
-       'model' => 'gpt-4o',
-       'api_key' => env('OPENAI_API_KEY'),
-   ],
-   ```
-
-   Or for Gemini:
-
-   ```php
-   'ai' => [
-       'provider' => 'gemini',
-       'model' => 'gemini-2.5-pro-preview-05-06',
-       'api_key' => env('GEMINI_API_KEY'),
-   ],
-   ```
-
-   Then, add the OpenAI or Gemini API key to your `.env` file:
-
-   ```
-   OPENAI_API_KEY=your-openai-api-key-here
-   GEMINI_API_KEY=your-gemini-api-key-here
-   ```
-
-   You can obtain API keys from:
-   - OpenAI: [OpenAI Platform](https://platform.openai.com/account/api-keys)
-   - Gemini: [Google AI Studio](https://aistudio.google.com/app/apikey)
-
-   **We strongly recommend using Claude for the best translation quality and accuracy.**
+4. (Optional) Change `ai.model` in `config/ai-translator.php`. See the configuration section below and [OpenRouter Models](https://openrouter.ai/models) for current model IDs and limits.
 
 5. You're now ready to use the Laravel AI Translator!
 
@@ -467,69 +431,37 @@ This will create a `config/ai-translator.php` file where you can modify the foll
 
   ```php
   'ai' => [
-      'provider' => 'anthropic',
-      'model' => 'claude-sonnet-4-20250514',
-      'api_key' => env('ANTHROPIC_API_KEY'),
+      'provider' => 'openrouter',
+      'model' => 'vendor/model-id',
+      'api_key' => env('OPENROUTER_API_KEY'),
   ],
   ```
 
-  This package supports Anthropic's Claude, Google's Gemini, and OpenAI's GPT models for translations. Here are the tested and verified models:
+  The package default is defined in [`config/ai-translator.php`](config/ai-translator.php). Other current frontier model examples:
 
-  | Provider    | Model                            | Extended Thinking | Context Window | Max Tokens |
-  | ----------- | -------------------------------- | ----------------- | -------------- | ---------- |
-  | `anthropic` | `claude-sonnet-4-20250514`       | ✅                | 200K           | 8K/64K\*   |
-  | `anthropic` | `claude-3-7-sonnet-latest`       | ✅                | 200K           | 8K/64K\*   |
-  | `anthropic` | `claude-3-7-sonnet-latest`       | ❌                | 200K           | 8K         |
-  | `anthropic` | `claude-3-haiku-20240307`        | ❌                | 200K           | 8K         |
-  | `openai`    | `gpt-4o`                         | ❌                | 128K           | 4K         |
-  | `openai`    | `gpt-4o-mini`                    | ❌                | 128K           | 4K         |
-  | `gemini`    | `gemini-2.5-pro-preview-05-06`   | ❌                | 1000K          | 64K        |
-  | `gemini`    | `gemini-2.5-flash-preview-04-17` | ❌                | 1000K          | 64K        |
+  | Provider     | Model                           |
+  | ------------ | ------------------------------- |
+  | `openrouter` | `openai/gpt-5.6-sol`            |
+  | `openrouter` | `google/gemini-3.1-pro-preview` |
 
-  \* 8K tokens for normal mode, 64K tokens when extended thinking is enabled
-
-  For available models:
-
-  - Anthropic: See [Anthropic Models Documentation](https://docs.anthropic.com/en/docs/about-claude/models)
-  - OpenAI: See [OpenAI Models Documentation](https://platform.openai.com/docs/models)
-
-  > **⭐️ Strong Recommendation**: We highly recommend using Anthropic's Claude models, particularly `claude-sonnet-4-20250514` or `claude-3-7-sonnet-latest`. Here's why:
-  >
-  > - More accurate and natural translations
-  > - Better understanding of context and nuances
-  > - More consistent output quality
-  > - More cost-effective for the quality provided
-  > - Claude 4.0 offers even better reasoning and translation quality
-  >
-  > While OpenAI integration is available, we strongly advise against using it for translations. Our extensive testing has shown that Claude models consistently produce superior results for localization tasks.
+  Check current availability and limits in the [OpenRouter model catalog](https://openrouter.ai/models).
 
   ### Provider Setup
 
-  1. Get your API key:
-
-     - Anthropic: [Console API Keys](https://console.anthropic.com/settings/keys)
-     - OpenAI: [API Keys](https://platform.openai.com/api-keys)
-     - Gemini: [Google AI Studio](https://aistudio.google.com/app/apikey)
+  1. Create an API key in [OpenRouter](https://openrouter.ai/settings/keys).
 
   2. Add to your `.env` file:
 
      ```env
-     # For Anthropic
-     ANTHROPIC_API_KEY=your-api-key
-
-     # For OpenAI
-     OPENAI_API_KEY=your-api-key
-
-     # For Gemini
-     GEMINI_API_KEY=your-api-key
+     OPENROUTER_API_KEY=your-api-key
      ```
 
   3. Configure in `config/ai-translator.php`:
      ```php
      'ai' => [
-        'provider' => 'anthropic', // or 'openai' or 'gemini'
-        'model' => 'claude-sonnet-4-20250514', // see model list above
-        'api_key' => env('ANTHROPIC_API_KEY'), // or env('OPENAI_API_KEY') or env('GEMINI_API_KEY')
+        'provider' => 'openrouter',
+        'model' => 'vendor/model-id',
+        'api_key' => env('OPENROUTER_API_KEY'),
      ],
      ```
 
@@ -548,9 +480,9 @@ return [
     'source_directory' => 'lang',
 
     'ai' => [
-        'provider' => 'anthropic',
-        'model' => 'claude-sonnet-4-20250514',
-        'api_key' => env('ANTHROPIC_API_KEY'),
+        'provider' => 'openrouter',
+        'model' => 'vendor/model-id',
+        'api_key' => env('OPENROUTER_API_KEY'),
     ],
 
     'locale_names' => [
@@ -662,7 +594,6 @@ We're constantly working to improve Laravel AI Translator. Here are some feature
 - [ ] Implement strict validation for translations:
   - Verify that variables are correctly preserved in translated strings
   - Check for consistency in pluralization rules across translations
-- [ ] Expand support for other LLMs (such as Gemini)
 - [ ] Replace regex-based XML parser with proper XML parsing:
   - Better handle edge cases and malformed XML
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AI-powered translation tool for Laravel language files
 - 🔁 **Parallel Translation**: Translate multiple locales concurrently with the `translate-parallel` command
 - **OpenRouter Provider**: Uses PrismPHP to access current frontier models through one API
   - Defaults to Claude Opus 5
-  - Supports GPT-5.6 Sol and Gemini 3.1 Pro Preview model IDs
+  - Supports GPT-5.6 Sol and Gemini 3.7 Flash model IDs
   - Supports streaming responses and reasoning callbacks
 - **Visual Logging Improvements**: Completely redesigned logging system
   - 🎨 Beautiful color-coded console output
@@ -59,7 +59,7 @@ Laravel AI Translator is a powerful tool designed to streamline the localization
 Key benefits:
 
 - Time-saving: Translate all your language files with one simple command
-- AI-powered: Uses current frontier models such as Claude Opus 5, GPT-5.6 Sol, and Gemini 3.1 Pro Preview
+- AI-powered: Uses current frontier models such as Claude Opus 5, GPT-5.6 Sol, and Gemini 3.7 Flash
 - Smart context understanding: Accurately captures nuances, technical terms, and Laravel-specific expressions
 - Seamless integration: Works within your existing Laravel project structure, preserving complex language file structures
 
@@ -442,7 +442,7 @@ This will create a `config/ai-translator.php` file where you can modify the foll
   | Provider     | Model                           |
   | ------------ | ------------------------------- |
   | `openrouter` | `openai/gpt-5.6-sol`            |
-  | `openrouter` | `google/gemini-3.1-pro-preview` |
+  | `openrouter` | `google/gemini-3.7-flash`       |
 
   Check current availability and limits in the [OpenRouter model catalog](https://openrouter.ai/models).
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ AI-powered translation tool for Laravel language files
   - Better handling of backup directories
   - Strict path matching to prevent unintended deletions
 - 🔁 **Parallel Translation**: Translate multiple locales concurrently with the `translate-parallel` command
-- **OpenRouter Provider**: Uses PrismPHP to access current frontier models through one API
-  - Defaults to Claude Opus 5
+- **AI Providers**: Uses OpenRouter by default while retaining direct OpenAI, Anthropic, and Gemini support
+  - Uses PrismPHP for OpenRouter with Claude Opus 5 as the default model
   - Supports GPT-5.6 Sol and Gemini 3.7 Flash model IDs
   - Supports streaming responses and reasoning callbacks
+  - Loads pricing from OpenRouter for every provider and caches the catalog for six hours
 - **Visual Logging Improvements**: Completely redesigned logging system
   - 🎨 Beautiful color-coded console output
   - 📊 Real-time progress indicators
@@ -437,18 +438,24 @@ This will create a `config/ai-translator.php` file where you can modify the foll
   ],
   ```
 
-  The package default is defined in [`config/ai-translator.php`](config/ai-translator.php). Other current frontier model examples:
+  OpenRouter is the default, not the only supported provider. The package default is defined in [`config/ai-translator.php`](config/ai-translator.php). Current provider examples:
 
-  | Provider     | Model                           |
-  | ------------ | ------------------------------- |
-  | `openrouter` | `openai/gpt-5.6-sol`            |
-  | `openrouter` | `google/gemini-3.7-flash`       |
+  | Provider               | Model                           | API key variable        |
+  | ---------------------- | ------------------------------- | ----------------------- |
+  | `openrouter` (default) | `anthropic/claude-opus-5`       | `OPENROUTER_API_KEY`    |
+  | `openrouter`           | `openai/gpt-5.6-sol`            | `OPENROUTER_API_KEY`    |
+  | `openrouter`           | `google/gemini-3.7-flash`       | `OPENROUTER_API_KEY`    |
+  | `openai`               | `gpt-5.6-sol`                   | `OPENAI_API_KEY`        |
+  | `anthropic`            | `claude-opus-5`                 | `ANTHROPIC_API_KEY`     |
+  | `gemini`               | `gemini-3.7-flash`              | `GEMINI_API_KEY`        |
 
   Check current availability and limits in the [OpenRouter model catalog](https://openrouter.ai/models).
 
+  Cost reports use the public OpenRouter model catalog for both OpenRouter and direct-provider requests. The catalog is cached for six hours, and direct-provider credentials are never sent to OpenRouter.
+
   ### Provider Setup
 
-  1. Create an API key in [OpenRouter](https://openrouter.ai/settings/keys).
+  1. Create an API key for the provider you want to use. For the default provider, create one in [OpenRouter](https://openrouter.ai/settings/keys).
 
   2. Add to your `.env` file:
 
@@ -456,7 +463,7 @@ This will create a `config/ai-translator.php` file where you can modify the foll
      OPENROUTER_API_KEY=your-api-key
      ```
 
-  3. Configure in `config/ai-translator.php`:
+  3. Configure the matching provider, model, and API key in `config/ai-translator.php`:
      ```php
      'ai' => [
         'provider' => 'openrouter',

--- a/composer.json
+++ b/composer.json
@@ -22,18 +22,19 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "crowdin/crowdin-api-client": "^1.14",
         "google-gemini-php/client": "^1.0|^2.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "guzzlehttp/promises": "^1.0|^2.0",
-        "illuminate/support": ">=8.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "openai-php/client": ">=0.2 <1.0",
+        "prism-php/prism": "^0.100.1",
         "symfony/process": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^1.0|^2.0|^3.0",
         "pestphp/pest-plugin-laravel": "^1.0|^2.0|^3.0",
         "phpstan/phpstan": "^2.1",

--- a/config/ai-translator.php
+++ b/config/ai-translator.php
@@ -8,6 +8,7 @@ return [
     'source_locale' => 'en',
 
     'ai' => [
+        // Supported providers: OpenRouter (default), OpenAI, Anthropic, and Gemini.
         'provider' => 'openrouter',
         'model' => 'anthropic/claude-opus-5',
         'api_key' => env('OPENROUTER_API_KEY'),

--- a/config/ai-translator.php
+++ b/config/ai-translator.php
@@ -17,7 +17,7 @@ return [
         // 'retries' => 5,
         // 'max_tokens' => 128000,
         // 'reasoning' => ['effort' => 'high'],
-        // 'use_extended_thinking' => false, // Anthropic direct provider only.
+        // 'use_extended_thinking' => false, // Claude 3.7 with the Anthropic direct provider only.
         // 'disable_stream' => true, // Disable streaming mode for better error messages
 
         // 'prompt_custom_system_file_path' => null, // Full path to your own custom prompt-system.txt - i.e. resource_path('prompt-system.txt')

--- a/config/ai-translator.php
+++ b/config/ai-translator.php
@@ -8,34 +8,15 @@ return [
     'source_locale' => 'en',
 
     'ai' => [
-        'provider' => 'anthropic',
-        'model' => 'claude-3-5-sonnet-latest', // Best result. Recommend for production.
-        'api_key' => env('ANTHROPIC_API_KEY'),
-
-        // claude-3-haiku
-        // 'provider' => 'anthropic',
-        // 'model' => 'claude-3-haiku-20240307', // Recommend to use for testing purpose. It's better than gpt-3.5
-        // 'api_key' => env('ANTHROPIC_API_KEY'),
-
-        // gpt-4o
-        // 'provider' => 'openai',
-        // 'model' => 'gpt-4o', // Balanced. Normal price, normal accuracy. Recommend for production.
-        // 'api_key' => env('OPENAI_API_KEY'),
-
-        // gpt-4o-mini
-        // 'provider' => 'openai',
-        // 'model' => 'gpt-4o-mini', // Recommend to use for testing purpose. It sometimes doesn't translate.
-        // 'api_key' => env('OPENAI_API_KEY'),
-
-        // gemini-2.5-pro-preview-05-06
-        // 'provider' => 'gemini',
-        // 'model' => 'gemini-2.5-pro-preview-05-06',
-        // 'api_key' => env('GEMINI_API_KEY'),
+        'provider' => 'openrouter',
+        'model' => 'anthropic/claude-opus-5',
+        'api_key' => env('OPENROUTER_API_KEY'),
 
         // Additional options
         // 'retries' => 5,
-        // 'max_tokens' => 4096,
-        // 'use_extended_thinking' => false, // Extended Thinking 기능 사용 여부 (claude-3-7-sonnet-latest 모델만 지원)
+        // 'max_tokens' => 128000,
+        // 'reasoning' => ['effort' => 'high'],
+        // 'use_extended_thinking' => false, // Anthropic direct provider only.
         // 'disable_stream' => true, // Disable streaming mode for better error messages
 
         // 'prompt_custom_system_file_path' => null, // Full path to your own custom prompt-system.txt - i.e. resource_path('prompt-system.txt')

--- a/src/AI/AIProvider.php
+++ b/src/AI/AIProvider.php
@@ -13,6 +13,14 @@ use Kargnas\LaravelAiTranslator\Enums\PromptType;
 use Kargnas\LaravelAiTranslator\Enums\TranslationStatus;
 use Kargnas\LaravelAiTranslator\Exceptions\VerifyFailedException;
 use Kargnas\LaravelAiTranslator\Models\LocalizedString;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Streaming\Events\StreamEndEvent;
+use Prism\Prism\Streaming\Events\TextDeltaEvent;
+use Prism\Prism\Streaming\Events\ThinkingCompleteEvent;
+use Prism\Prism\Streaming\Events\ThinkingEvent;
+use Prism\Prism\Streaming\Events\ThinkingStartEvent;
+use Prism\Prism\ValueObjects\Usage;
 
 class AIProvider
 {
@@ -382,11 +390,108 @@ class AIProvider
     protected function getTranslatedObjects(): array
     {
         return match ($this->configProvider) {
+            'openrouter' => $this->getTranslatedObjectsFromOpenRouter(),
             'anthropic' => $this->getTranslatedObjectsFromAnthropic(),
             'openai' => $this->getTranslatedObjectsFromOpenAI(),
             'gemini' => $this->getTranslatedObjectsFromGemini(),
             default => throw new \Exception("Provider {$this->configProvider} is not supported."),
         };
+    }
+
+    protected function getTranslatedObjectsFromOpenRouter(): array
+    {
+        $responseParser = new AIResponseParser($this->onTranslated, config('app.debug', false));
+        $request = Prism::text()
+            ->using(Provider::OpenRouter, $this->configModel, [
+                'api_key' => config('ai-translator.ai.api_key'),
+            ])
+            ->withSystemPrompt($this->getSystemPrompt())
+            ->withPrompt($this->getUserPrompt())
+            ->usingTemperature(config('ai-translator.ai.temperature'))
+            ->withMaxTokens((int) config('ai-translator.ai.max_tokens', 128000))
+            ->withProviderOptions([
+                'reasoning' => config('ai-translator.ai.reasoning'),
+            ]);
+
+        if (config('ai-translator.ai.disable_stream', false)) {
+            $response = $request->asText();
+            $this->trackPrismUsage($response->usage);
+            $responseParser->parse($response->text);
+
+            if ($this->onProgress) {
+                ($this->onProgress)($response->text, $responseParser->getTranslatedItems());
+            }
+
+            return $responseParser->getTranslatedItems();
+        }
+
+        $responseText = '';
+        $thinkingContent = '';
+
+        foreach ($request->asStream() as $event) {
+            if ($event instanceof StreamEndEvent && $event->usage !== null) {
+                $this->trackPrismUsage($event->usage);
+            }
+
+            if ($event instanceof ThinkingStartEvent) {
+                $thinkingContent = '';
+
+                if ($this->onThinkingStart) {
+                    ($this->onThinkingStart)();
+                }
+
+                continue;
+            }
+
+            if ($event instanceof ThinkingEvent) {
+                $thinkingContent .= $event->delta;
+
+                if ($this->onThinking) {
+                    ($this->onThinking)($event->delta);
+                }
+
+                continue;
+            }
+
+            if ($event instanceof ThinkingCompleteEvent) {
+                if ($this->onThinkingEnd) {
+                    ($this->onThinkingEnd)($thinkingContent);
+                }
+
+                continue;
+            }
+
+            if (! $event instanceof TextDeltaEvent) {
+                continue;
+            }
+
+            $responseText .= $event->delta;
+            $responseParser->parseChunk($event->delta);
+
+            if ($this->onProgress) {
+                ($this->onProgress)($event->delta, $responseParser->getTranslatedItems());
+            }
+        }
+
+        if ($responseParser->getTranslatedItems() === [] && $responseText !== '') {
+            $responseParser->parse($responseText);
+        }
+
+        return $responseParser->getTranslatedItems();
+    }
+
+    protected function trackPrismUsage(Usage $usage): void
+    {
+        $this->inputTokens = $usage->promptTokens;
+        $this->outputTokens = $usage->completionTokens;
+        $this->totalTokens = $this->inputTokens + $this->outputTokens;
+
+        // Existing console callbacks expect an intermediate update before translate() emits the final one.
+        if ($this->onTokenUsage) {
+            $tokenUsage = $this->getTokenUsage();
+            $tokenUsage['final'] = false;
+            ($this->onTokenUsage)($tokenUsage);
+        }
     }
 
     protected function getTranslatedObjectsFromOpenAI(): array

--- a/src/AI/AIProvider.php
+++ b/src/AI/AIProvider.php
@@ -44,6 +44,10 @@ class AIProvider
 
     protected int $outputTokens = 0;
 
+    protected int $cacheCreationInputTokens = 0;
+
+    protected int $cacheReadInputTokens = 0;
+
     protected int $totalTokens = 0;
 
     // Callback properties
@@ -102,6 +106,8 @@ class AIProvider
         // Initialize tokens
         $this->inputTokens = 0;
         $this->outputTokens = 0;
+        $this->cacheCreationInputTokens = 0;
+        $this->cacheReadInputTokens = 0;
         $this->totalTokens = 0;
 
         Log::info("AIProvider initiated: Source language = {$this->sourceLanguageObj->name} ({$this->sourceLanguageObj->code}), Target language = {$this->targetLanguageObj->name} ({$this->targetLanguageObj->code})");
@@ -406,12 +412,22 @@ class AIProvider
                 'api_key' => config('ai-translator.ai.api_key'),
             ])
             ->withSystemPrompt($this->getSystemPrompt())
-            ->withPrompt($this->getUserPrompt())
-            ->usingTemperature(config('ai-translator.ai.temperature'))
-            ->withMaxTokens((int) config('ai-translator.ai.max_tokens', 128000))
-            ->withProviderOptions([
-                'reasoning' => config('ai-translator.ai.reasoning'),
-            ]);
+            ->withPrompt($this->getUserPrompt());
+
+        $temperature = config('ai-translator.ai.temperature');
+        if ($temperature !== null) {
+            $request->usingTemperature($temperature);
+        }
+
+        $maxTokens = config('ai-translator.ai.max_tokens');
+        if ($maxTokens !== null) {
+            $request->withMaxTokens((int) $maxTokens);
+        }
+
+        $reasoning = config('ai-translator.ai.reasoning');
+        if ($reasoning !== null) {
+            $request->withProviderOptions(['reasoning' => $reasoning]);
+        }
 
         if (config('ai-translator.ai.disable_stream', false)) {
             $response = $request->asText();
@@ -420,6 +436,13 @@ class AIProvider
 
             if ($this->onProgress) {
                 ($this->onProgress)($response->text, $responseParser->getTranslatedItems());
+            }
+
+            if ($this->onTranslated) {
+                foreach ($responseParser->getTranslatedItems() as $item) {
+                    ($this->onTranslated)($item, TranslationStatus::STARTED, $responseParser->getTranslatedItems());
+                    ($this->onTranslated)($item, TranslationStatus::COMPLETED, $responseParser->getTranslatedItems());
+                }
             }
 
             return $responseParser->getTranslatedItems();
@@ -466,10 +489,18 @@ class AIProvider
             }
 
             $responseText .= $event->delta;
+            $previousItemCount = count($responseParser->getTranslatedItems());
             $responseParser->parseChunk($event->delta);
+            $translatedItems = $responseParser->getTranslatedItems();
+
+            if ($this->onTranslated) {
+                foreach (array_slice($translatedItems, $previousItemCount) as $item) {
+                    ($this->onTranslated)($item, TranslationStatus::COMPLETED, $translatedItems);
+                }
+            }
 
             if ($this->onProgress) {
-                ($this->onProgress)($event->delta, $responseParser->getTranslatedItems());
+                ($this->onProgress)($event->delta, $translatedItems);
             }
         }
 
@@ -482,9 +513,18 @@ class AIProvider
 
     protected function trackPrismUsage(Usage $usage): void
     {
-        $this->inputTokens = $usage->promptTokens;
+        $this->cacheCreationInputTokens = $usage->cacheWriteInputTokens ?? 0;
+        $this->cacheReadInputTokens = $usage->cacheReadInputTokens ?? 0;
+        // OpenRouter includes cache reads in promptTokens but exposes cache writes separately.
+        $this->inputTokens = max(
+            0,
+            $usage->promptTokens - $this->cacheReadInputTokens
+        );
         $this->outputTokens = $usage->completionTokens;
-        $this->totalTokens = $this->inputTokens + $this->outputTokens;
+        $this->totalTokens = $this->inputTokens
+            + $this->outputTokens
+            + $this->cacheCreationInputTokens
+            + $this->cacheReadInputTokens;
 
         // Existing console callbacks expect an intermediate update before translate() emits the final one.
         if ($this->onTokenUsage) {
@@ -609,6 +649,8 @@ class AIProvider
         // 토큰 사용량 초기화
         $this->inputTokens = 0;
         $this->outputTokens = 0;
+        $this->cacheCreationInputTokens = 0;
+        $this->cacheReadInputTokens = 0;
         $this->totalTokens = 0;
 
         // Initialize response parser with debug mode enabled in development
@@ -815,15 +857,7 @@ class AIProvider
 
             // 토큰 사용량 최종 확인
             if (isset($response['usage'])) {
-                if (isset($response['usage']['input_tokens'])) {
-                    $this->inputTokens = (int) $response['usage']['input_tokens'];
-                }
-
-                if (isset($response['usage']['output_tokens'])) {
-                    $this->outputTokens = (int) $response['usage']['output_tokens'];
-                }
-
-                $this->totalTokens = $this->inputTokens + $this->outputTokens;
+                $this->extractTokensFromUsage($response['usage']);
             }
 
             // 디버깅: 최종 응답 구조 로깅
@@ -841,13 +875,7 @@ class AIProvider
 
             // 토큰 사용량 추적 (스트리밍이 아닌 경우)
             if (isset($response['usage'])) {
-                if (isset($response['usage']['input_tokens'])) {
-                    $this->inputTokens = $response['usage']['input_tokens'];
-                }
-                if (isset($response['usage']['output_tokens'])) {
-                    $this->outputTokens = $response['usage']['output_tokens'];
-                }
-                $this->totalTokens = $this->inputTokens + $this->outputTokens;
+                $this->extractTokensFromUsage($response['usage']);
             }
 
             $responseText = $response['content'][0]['text'];
@@ -918,8 +946,8 @@ class AIProvider
         return [
             'input_tokens' => $this->inputTokens,
             'output_tokens' => $this->outputTokens,
-            'cache_creation_input_tokens' => null,
-            'cache_read_input_tokens' => null,
+            'cache_creation_input_tokens' => $this->cacheCreationInputTokens,
+            'cache_read_input_tokens' => $this->cacheReadInputTokens,
             'total_tokens' => $this->totalTokens,
         ];
     }
@@ -1017,7 +1045,18 @@ class AIProvider
             $this->outputTokens = (int) $usage['output_tokens'];
         }
 
-        $this->totalTokens = $this->inputTokens + $this->outputTokens;
+        if (isset($usage['cache_creation_input_tokens'])) {
+            $this->cacheCreationInputTokens = (int) $usage['cache_creation_input_tokens'];
+        }
+
+        if (isset($usage['cache_read_input_tokens'])) {
+            $this->cacheReadInputTokens = (int) $usage['cache_read_input_tokens'];
+        }
+
+        $this->totalTokens = $this->inputTokens
+            + $this->outputTokens
+            + $this->cacheCreationInputTokens
+            + $this->cacheReadInputTokens;
     }
 
     /**

--- a/src/AI/Printer/TokenUsagePrinter.php
+++ b/src/AI/Printer/TokenUsagePrinter.php
@@ -336,6 +336,11 @@ class TokenUsagePrinter
             return;
         }
 
+        // printCostEstimation already reported this catalog-level failure for a full report.
+        if ($this->pricingError !== null) {
+            return;
+        }
+
         $command->line("\n".str_repeat('─', 80));
         $command->line($this->colors['blue_bg'].$this->colors['white'].$this->colors['bold'].' Model Cost Comparison '.$this->colors['reset']);
 

--- a/src/AI/Printer/TokenUsagePrinter.php
+++ b/src/AI/Printer/TokenUsagePrinter.php
@@ -9,6 +9,12 @@ use Illuminate\Console\Command;
  */
 class TokenUsagePrinter
 {
+    public const MODEL_CLAUDE_OPUS_5 = 'anthropic/claude-opus-5';
+
+    public const MODEL_GPT_5_6_SOL = 'openai/gpt-5.6-sol';
+
+    public const MODEL_GEMINI_3_1_PRO = 'google/gemini-3.1-pro-preview';
+
     /**
      * 지원되는 모델 목록
      */
@@ -19,7 +25,7 @@ class TokenUsagePrinter
 
     public const MODEL_CLAUDE_3_HAIKU = 'claude-3-haiku-20240307';
 
-    // Current models
+    // Older direct-provider models
     public const MODEL_CLAUDE_3_5_SONNET = 'claude-3-5-sonnet-20241022';
 
     public const MODEL_CLAUDE_3_5_HAIKU = 'claude-3-5-haiku-20241022';
@@ -31,10 +37,33 @@ class TokenUsagePrinter
     public const MODEL_CLAUDE_OPUS_4 = 'claude-opus-4-20250514';
 
     public const MODEL_CLAUDE_OPUS_4_1 = 'claude-opus-4-1-20250805';
+
     /**
      * 모델별 가격 정보 ($ per million tokens)
      */
     protected const MODEL_RATES = [
+        self::MODEL_CLAUDE_OPUS_5 => [
+            'input' => 5.0,
+            'output' => 25.0,
+            'cache_write' => 6.25,
+            'cache_read' => 0.5,
+            'name' => 'Claude Opus 5',
+        ],
+        self::MODEL_GPT_5_6_SOL => [
+            'input' => 5.0,
+            'output' => 30.0,
+            'cache_write' => 6.25,
+            'cache_read' => 0.5,
+            'name' => 'GPT-5.6 Sol',
+        ],
+        self::MODEL_GEMINI_3_1_PRO => [
+            'input' => 2.0,
+            'output' => 12.0,
+            'cache_write' => 0.375,
+            'cache_read' => 0.2,
+            'name' => 'Gemini 3.1 Pro Preview',
+        ],
+
         // Opus models
         self::MODEL_CLAUDE_OPUS_4_1 => [
             'input' => 15.0,

--- a/src/AI/Printer/TokenUsagePrinter.php
+++ b/src/AI/Printer/TokenUsagePrinter.php
@@ -3,141 +3,32 @@
 namespace Kargnas\LaravelAiTranslator\AI\Printer;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+use Throwable;
 
 /**
  * 토큰 사용량 및 비용 계산을 출력하는 유틸리티 클래스
  */
 class TokenUsagePrinter
 {
-    public const MODEL_CLAUDE_OPUS_5 = 'anthropic/claude-opus-5';
+    protected const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
 
-    public const MODEL_GPT_5_6_SOL = 'openai/gpt-5.6-sol';
+    protected const PRICING_CACHE_KEY = 'laravel-ai-translator.openrouter-model-pricing';
 
-    public const MODEL_GEMINI_3_7_FLASH = 'google/gemini-3.7-flash';
+    protected const PRICING_CACHE_TTL_SECONDS = 21_600;
 
-    /**
-     * 지원되는 모델 목록
-     */
-    // Legacy models (for backward compatibility)
-    public const MODEL_CLAUDE_3_OPUS = 'claude-3-opus-20240229';
-
-    public const MODEL_CLAUDE_3_5_SONNET_OLD = 'claude-3-5-sonnet-20240620';
-
-    public const MODEL_CLAUDE_3_HAIKU = 'claude-3-haiku-20240307';
-
-    // Older direct-provider models
-    public const MODEL_CLAUDE_3_5_SONNET = 'claude-3-5-sonnet-20241022';
-
-    public const MODEL_CLAUDE_3_5_HAIKU = 'claude-3-5-haiku-20241022';
-
-    public const MODEL_CLAUDE_3_7_SONNET = 'claude-3-7-sonnet-20250219';
-
-    public const MODEL_CLAUDE_SONNET_4 = 'claude-sonnet-4-20250514';
-
-    public const MODEL_CLAUDE_OPUS_4 = 'claude-opus-4-20250514';
-
-    public const MODEL_CLAUDE_OPUS_4_1 = 'claude-opus-4-1-20250805';
-
-    /**
-     * 모델별 가격 정보 ($ per million tokens)
-     */
-    protected const MODEL_RATES = [
-        self::MODEL_CLAUDE_OPUS_5 => [
-            'input' => 5.0,
-            'output' => 25.0,
-            'cache_write' => 6.25,
-            'cache_read' => 0.5,
-            'name' => 'Claude Opus 5',
-        ],
-        self::MODEL_GPT_5_6_SOL => [
-            'input' => 5.0,
-            'output' => 30.0,
-            'cache_write' => 6.25,
-            'cache_read' => 0.5,
-            'name' => 'GPT-5.6 Sol',
-        ],
-        self::MODEL_GEMINI_3_7_FLASH => [
-            'input' => 0.375,
-            'output' => 1.875,
-            'cache_write' => 0.020833,
-            'cache_read' => 0.0375,
-            'name' => 'Gemini 3.7 Flash',
-        ],
-
-        // Opus models
-        self::MODEL_CLAUDE_OPUS_4_1 => [
-            'input' => 15.0,
-            'output' => 75.0,
-            'cache_write' => 18.75, // 25% 할증 (5m cache)
-            'cache_read' => 1.5,    // 10% (90% 할인)
-            'name' => 'Claude Opus 4.1',
-        ],
-        self::MODEL_CLAUDE_OPUS_4 => [
-            'input' => 15.0,
-            'output' => 75.0,
-            'cache_write' => 18.75, // 25% 할증 (5m cache)
-            'cache_read' => 1.5,    // 10% (90% 할인)
-            'name' => 'Claude Opus 4',
-        ],
-        self::MODEL_CLAUDE_3_OPUS => [
-            'input' => 15.0,
-            'output' => 75.0,
-            'cache_write' => 18.75, // 25% 할증
-            'cache_read' => 1.5,    // 10% (90% 할인)
-            'name' => 'Claude 3 Opus',
-        ],
-        
-        // Sonnet models
-        self::MODEL_CLAUDE_SONNET_4 => [
-            'input' => 3.0,
-            'output' => 15.0,
-            'cache_write' => 3.75,  // 25% 할증 (5m cache)
-            'cache_read' => 0.3,    // 10% (90% 할인)
-            'name' => 'Claude Sonnet 4',
-        ],
-        self::MODEL_CLAUDE_3_7_SONNET => [
-            'input' => 3.0,
-            'output' => 15.0,
-            'cache_write' => 3.75,  // 25% 할증 (5m cache)
-            'cache_read' => 0.3,    // 10% (90% 할인)
-            'name' => 'Claude 3.7 Sonnet',
-        ],
-        self::MODEL_CLAUDE_3_5_SONNET => [
-            'input' => 3.0,
-            'output' => 15.0,
-            'cache_write' => 3.75,  // 25% 할증 (5m cache)
-            'cache_read' => 0.3,    // 10% (90% 할인)
-            'name' => 'Claude 3.5 Sonnet',
-        ],
-        self::MODEL_CLAUDE_3_5_SONNET_OLD => [
-            'input' => 3.0,
-            'output' => 15.0,
-            'cache_write' => 3.75,  // 25% 할증
-            'cache_read' => 0.3,    // 10% (90% 할인)
-            'name' => 'Claude 3.5 Sonnet (old)',
-        ],
-        
-        // Haiku models
-        self::MODEL_CLAUDE_3_5_HAIKU => [
-            'input' => 0.80,
-            'output' => 4.0,
-            'cache_write' => 1.0,   // 25% 할증 (5m cache)
-            'cache_read' => 0.08,   // 10% (90% 할인)
-            'name' => 'Claude 3.5 Haiku',
-        ],
-        self::MODEL_CLAUDE_3_HAIKU => [
-            'input' => 0.25,
-            'output' => 1.25,
-            'cache_write' => 0.30,  // 20% 할증 (5m cache)
-            'cache_read' => 0.03,   // 12% (88% 할인)
-            'name' => 'Claude 3 Haiku',
-        ],
+    protected const COMPARISON_MODELS = [
+        'anthropic/claude-opus-5',
+        'openai/gpt-5.6-sol',
+        'google/gemini-3.7-flash',
     ];
 
     /**
      * 사용자 정의 색상 코드
      */
-    protected $colors = [
+    protected array $colors = [
         'gray' => "\033[38;5;245m",
         'blue' => "\033[38;5;33m",
         'green' => "\033[38;5;40m",
@@ -153,205 +44,230 @@ class TokenUsagePrinter
         'line_clear' => "\033[2K\r",
     ];
 
-    /**
-     * 현재 사용 중인 모델
-     */
-    protected string $currentModel;
+    protected ?string $currentModel;
 
-    /**
-     * 원래 모델
-     */
-    protected ?string $originalModel = null;
+    protected string $provider;
 
-    /**
-     * 생성자
-     */
-    public function __construct(?string $model = null)
+    protected ?array $openRouterModels = null;
+
+    protected ?RuntimeException $pricingError = null;
+
+    public function __construct(?string $model = null, ?string $provider = null)
     {
-        // 모델이 지정되지 않으면 그대로 null 유지
         $this->currentModel = $model;
-        $this->originalModel = $model;
-
-        // 지정된 모델이 있지만 정확히 일치하지 않는 경우, 가장 유사한 모델 찾기
-        if ($this->currentModel !== null && ! isset(self::MODEL_RATES[$this->currentModel])) {
-            $this->currentModel = $this->findClosestModel($this->currentModel);
-        }
+        $this->provider = $provider ?? (string) config('ai-translator.ai.provider', 'openrouter');
     }
 
-    /**
-     * 모델명에서 버전 번호와 접미사를 제거하고 정규화합니다.
-     */
-    protected function normalizeModelName(string $modelName): string
-    {
-        // 접미사 제거 및 소문자로 변환
-        return strtolower(preg_replace('/-(?:latest|\d+)/', '', $modelName));
-    }
-
-    /**
-     * 사람이 읽기 쉬운 형식의 모델명으로 변환합니다.
-     */
-    protected function getHumanReadableModelName(string $modelId): string
-    {
-        $name = $modelId;
-
-        // 기존 모델 이름으로 매핑
-        if (isset(self::MODEL_RATES[$modelId])) {
-            return self::MODEL_RATES[$modelId]['name'];
-        }
-
-        // 기본 모델명 정리
-        $name = preg_replace('/-(?:latest|\d+)/', '', $name);
-        $name = str_replace('-', ' ', $name);
-        $name = ucwords($name); // 각 단어 첫 글자 대문자로
-
-        return $name;
-    }
-
-    /**
-     * 가장 유사한 모델을 찾아 반환합니다.
-     *
-     * @param  string  $modelName  모델 이름
-     * @return string 가장 유사한 등록된 모델 이름
-     */
-    protected function findClosestModel(string $modelName): string
-    {
-        $bestMatch = self::MODEL_CLAUDE_3_5_SONNET; // 기본값
-        $bestScore = 0;
-
-        // 정규식으로 접미사 제거 (-latest 또는 -숫자 형식)
-        $simplifiedName = $this->normalizeModelName($modelName);
-
-        // 정확한 매칭부터 시도
-        foreach (array_keys(self::MODEL_RATES) as $availableModel) {
-            $simplifiedAvailableModel = $this->normalizeModelName($availableModel);
-
-            // 정확한 매칭이면 바로 반환
-            if ($simplifiedName === $simplifiedAvailableModel) {
-                return $availableModel;
-            }
-
-            // 부분 매칭 검사
-            if (
-                stripos($simplifiedAvailableModel, $simplifiedName) !== false ||
-                stripos($simplifiedName, $simplifiedAvailableModel) !== false
-            ) {
-
-                // 유사도 점수 계산
-                $score = $this->calculateSimilarity($simplifiedName, $simplifiedAvailableModel);
-
-                // 주요 모델 타입 일치 (haiku, sonnet, opus) 시 가산점
-                if (stripos($simplifiedName, 'haiku') !== false && stripos($simplifiedAvailableModel, 'haiku') !== false) {
-                    $score += 0.2;
-                } elseif (stripos($simplifiedName, 'sonnet') !== false && stripos($simplifiedAvailableModel, 'sonnet') !== false) {
-                    $score += 0.2;
-                } elseif (stripos($simplifiedName, 'opus') !== false && stripos($simplifiedAvailableModel, 'opus') !== false) {
-                    $score += 0.2;
-                }
-
-                // Add a bonus for exact version matches
-                if (
-                    preg_match('/claude-(\d+(?:\-\d+)?)/', $simplifiedName, $inputMatches) &&
-                    preg_match('/claude-(\d+(?:\-\d+)?)/', $simplifiedAvailableModel, $availableMatches)
-                ) {
-                    if ($inputMatches[1] === $availableMatches[1]) {
-                        $score += 0.3;
-                    }
-                }
-
-                if ($score > $bestScore) {
-                    $bestScore = $score;
-                    $bestMatch = $availableModel;
-                }
-            }
-        }
-
-        return $bestMatch;
-    }
-
-    /**
-     * 두 문자열 간의 유사도를 계산합니다.
-     *
-     * @param  string  $str1  첫 번째 문자열
-     * @param  string  $str2  두 번째 문자열
-     * @return float 0~1 사이의 유사도 값 (1이 완전 일치)
-     */
-    protected function calculateSimilarity(string $str1, string $str2): float
-    {
-        // 단순화된 유사도 계산: 공통 부분 문자열 길이 / 가장 긴 문자열 길이
-        $str1 = strtolower($str1);
-        $str2 = strtolower($str2);
-
-        // 레벤슈타인 거리 기반 유사도 계산
-        $levDistance = levenshtein($str1, $str2);
-        $maxLength = max(strlen($str1), strlen($str2));
-
-        // 거리가 작을수록 유사도는 높음
-        return 1 - ($levDistance / $maxLength);
-    }
-
-    /**
-     * 사용 중인 모델을 변경합니다
-     */
     public function setModel(string $model): self
     {
-        if ($model === null) {
-            $this->currentModel = null;
-            $this->originalModel = null;
-
-            return $this;
-        }
-
-        $this->originalModel = $model;
-
-        if (isset(self::MODEL_RATES[$model])) {
-            $this->currentModel = $model;
-        } else {
-            // 정확히 일치하지 않으면 가장 유사한 모델 찾기
-            $this->currentModel = $this->findClosestModel($model);
-        }
+        $this->currentModel = $model;
 
         return $this;
     }
 
-    /**
-     * 현재 사용 중인 모델에 대한 가격 정보를 반환합니다
-     */
-    protected function getModelRates(): array
+    protected function getOpenRouterModelId(string $model): string
     {
-        // 모델이 지정되지 않았거나 존재하지 않으면 기본 모델 사용
-        if ($this->currentModel === null || ! isset(self::MODEL_RATES[$this->currentModel])) {
-            return self::MODEL_RATES[self::MODEL_CLAUDE_3_5_SONNET];
+        if (str_contains($model, '/')) {
+            return $model;
         }
 
-        return self::MODEL_RATES[$this->currentModel];
+        return match ($this->provider) {
+            'openai' => "openai/{$model}",
+            'anthropic' => "anthropic/{$model}",
+            'gemini' => "google/{$model}",
+            default => $model,
+        };
     }
 
-    /**
-     * 현재 모델의 가격 계수를 반환합니다 ($ per token)
-     */
-    protected function getRateInput(): float
+    protected function getOpenRouterModels(): array
     {
-        return $this->getModelRates()['input'] / 1000000;
+        if ($this->pricingError !== null) {
+            throw $this->pricingError;
+        }
+
+        if ($this->openRouterModels !== null) {
+            return $this->openRouterModels;
+        }
+
+        try {
+            // The catalog is several megabytes, so cache it instead of downloading it for every report.
+            $models = Cache::remember(
+                self::PRICING_CACHE_KEY,
+                self::PRICING_CACHE_TTL_SECONDS,
+                function (): array {
+                    // Never forward a direct-provider API key to the public OpenRouter catalog.
+                    $response = Http::acceptJson()
+                        ->timeout(10)
+                        ->get(self::OPENROUTER_MODELS_URL);
+
+                    if (! $response->successful()) {
+                        throw new RuntimeException("OpenRouter pricing request failed with HTTP {$response->status()}.");
+                    }
+
+                    $models = $response->json('data');
+                    if (! is_array($models)) {
+                        throw new RuntimeException('OpenRouter pricing response did not contain a model catalog.');
+                    }
+
+                    return $models;
+                }
+            );
+
+            if (! is_array($models)) {
+                throw new RuntimeException('The cached OpenRouter model catalog is invalid.');
+            }
+
+            return $this->openRouterModels = $models;
+        } catch (RuntimeException $exception) {
+            $this->pricingError = $exception;
+
+            throw $exception;
+        } catch (Throwable $exception) {
+            $this->pricingError = new RuntimeException(
+                "OpenRouter pricing request failed: {$exception->getMessage()}",
+                0,
+                $exception
+            );
+
+            throw $this->pricingError;
+        }
     }
 
-    protected function getRateOutput(): float
+    protected function getModelRates(int $promptTokens, ?string $model = null): array
     {
-        return $this->getModelRates()['output'] / 1000000;
+        $requestedModel = $model ?? $this->currentModel;
+        if ($requestedModel === null || $requestedModel === '') {
+            throw new RuntimeException('A model is required to load pricing from OpenRouter.');
+        }
+
+        $openRouterModelId = $this->getOpenRouterModelId($requestedModel);
+        $modelData = null;
+
+        foreach ($this->getOpenRouterModels() as $candidate) {
+            if (is_array($candidate) && ($candidate['id'] ?? null) === $openRouterModelId) {
+                $modelData = $candidate;
+                break;
+            }
+        }
+
+        if ($modelData === null) {
+            throw new RuntimeException("Pricing for '{$requestedModel}' is not available from OpenRouter.");
+        }
+
+        $pricing = $modelData['pricing'] ?? null;
+        if (! is_array($pricing)) {
+            throw new RuntimeException("Pricing for '{$requestedModel}' is not available from OpenRouter.");
+        }
+
+        $pricing = $this->applyPricingOverride($pricing, $promptTokens);
+
+        return [
+            'id' => $openRouterModelId,
+            'name' => is_string($modelData['name'] ?? null) ? $modelData['name'] : $openRouterModelId,
+            'input' => $this->requiredPrice($pricing, 'prompt', $requestedModel),
+            'output' => $this->requiredPrice($pricing, 'completion', $requestedModel),
+            'cache_write' => $this->optionalPrice($pricing, 'input_cache_write'),
+            'cache_read' => $this->optionalPrice($pricing, 'input_cache_read'),
+        ];
     }
 
-    protected function getRateCacheWrite(): float
+    protected function applyPricingOverride(array $pricing, int $promptTokens): array
     {
-        return $this->getModelRates()['cache_write'] / 1000000;
+        $overrides = $pricing['overrides'] ?? [];
+        if (! is_array($overrides)) {
+            return $pricing;
+        }
+
+        usort($overrides, function ($left, $right): int {
+            return ((int) ($left['min_prompt_tokens'] ?? 0)) <=> ((int) ($right['min_prompt_tokens'] ?? 0));
+        });
+
+        foreach ($overrides as $override) {
+            if (! is_array($override)) {
+                continue;
+            }
+
+            $minimum = (int) ($override['min_prompt_tokens'] ?? 0);
+            $maximum = isset($override['max_prompt_tokens']) ? (int) $override['max_prompt_tokens'] : null;
+
+            if ($promptTokens < $minimum || ($maximum !== null && $promptTokens > $maximum)) {
+                continue;
+            }
+
+            $pricing = array_replace($pricing, $override);
+        }
+
+        return $pricing;
     }
 
-    protected function getRateCacheRead(): float
+    protected function requiredPrice(array $pricing, string $field, string $model): float
     {
-        return $this->getModelRates()['cache_read'] / 1000000;
+        $price = $pricing[$field] ?? null;
+        if (! is_numeric($price)) {
+            throw new RuntimeException("Pricing field '{$field}' for '{$model}' is not available from OpenRouter.");
+        }
+
+        return (float) $price;
     }
 
-    protected function getModelName(): string
+    protected function optionalPrice(array $pricing, string $field): ?float
     {
-        return $this->getModelRates()['name'];
+        $price = $pricing[$field] ?? null;
+
+        return is_numeric($price) ? (float) $price : null;
+    }
+
+    protected function getPromptTokenCount(array $usage): int
+    {
+        return (int) ($usage['input_tokens'] ?? 0)
+            + (int) ($usage['cache_creation_input_tokens'] ?? 0)
+            + (int) ($usage['cache_read_input_tokens'] ?? 0);
+    }
+
+    protected function calculateCosts(array $rates, array $usage): array
+    {
+        $inputTokens = (int) ($usage['input_tokens'] ?? 0);
+        $outputTokens = (int) ($usage['output_tokens'] ?? 0);
+        $cacheCreationTokens = (int) ($usage['cache_creation_input_tokens'] ?? 0);
+        $cacheReadTokens = (int) ($usage['cache_read_input_tokens'] ?? 0);
+
+        if ($cacheCreationTokens > 0 && $rates['cache_write'] === null) {
+            throw new RuntimeException("Cache-write pricing for '{$rates['id']}' is not available from OpenRouter.");
+        }
+
+        if ($cacheReadTokens > 0 && $rates['cache_read'] === null) {
+            throw new RuntimeException("Cache-read pricing for '{$rates['id']}' is not available from OpenRouter.");
+        }
+
+        $inputCost = $inputTokens * $rates['input'];
+        $outputCost = $outputTokens * $rates['output'];
+        $cacheCreationCost = $cacheCreationTokens * ($rates['cache_write'] ?? 0);
+        $cacheReadCost = $cacheReadTokens * ($rates['cache_read'] ?? 0);
+        $noCacheTotalCost = (($inputTokens + $cacheCreationTokens + $cacheReadTokens) * $rates['input']) + $outputCost;
+        $totalCost = $inputCost + $outputCost + $cacheCreationCost + $cacheReadCost;
+        $savedCost = $noCacheTotalCost - $totalCost;
+
+        return [
+            'input' => $inputCost,
+            'output' => $outputCost,
+            'cache_write' => $cacheCreationCost,
+            'cache_read' => $cacheReadCost,
+            'total' => $totalCost,
+            'no_cache_total' => $noCacheTotalCost,
+            'saved' => $savedCost,
+            'saved_percentage' => $noCacheTotalCost > 0 ? ($savedCost / $noCacheTotalCost) * 100 : 0,
+        ];
+    }
+
+    protected function formatRate(?float $rate): string
+    {
+        if ($rate === null) {
+            return 'Not listed';
+        }
+
+        $perMillion = rtrim(rtrim(number_format($rate * 1_000_000, 6, '.', ''), '0'), '.');
+
+        return "\${$perMillion} per million tokens";
     }
 
     /**
@@ -361,8 +277,6 @@ class TokenUsagePrinter
     {
         $command->line("\n".str_repeat('─', 80));
         $command->line($this->colors['blue_bg'].$this->colors['white'].$this->colors['bold'].' Token Usage Summary '.$this->colors['reset']);
-
-        // 토큰 사용량 테이블 출력
         $command->line($this->colors['yellow'].'Input Tokens'.$this->colors['reset'].': '.$this->colors['green'].$usage['input_tokens'].$this->colors['reset']);
         $command->line($this->colors['yellow'].'Output Tokens'.$this->colors['reset'].': '.$this->colors['green'].$usage['output_tokens'].$this->colors['reset']);
         $command->line($this->colors['yellow'].'Cache Created'.$this->colors['reset'].': '.$this->colors['blue'].$usage['cache_creation_input_tokens'].$this->colors['reset']);
@@ -375,59 +289,39 @@ class TokenUsagePrinter
      */
     public function printCostEstimation(Command $command, array $usage): void
     {
+        try {
+            $rates = $this->getModelRates($this->getPromptTokenCount($usage));
+            $costs = $this->calculateCosts($rates, $usage);
+        } catch (RuntimeException $exception) {
+            $command->warn($exception->getMessage());
+
+            return;
+        }
+
         $command->line("\n".str_repeat('─', 80));
-
-        // 원래 모델 이름과 매칭된 모델이 다를 경우 정보 제공
-        $modelHeader = ' Cost Estimation ('.$this->getModelName().') ';
-
-        // 원래 요청한 모델이 직접 매치되지 않은 경우
-        if ($this->originalModel && $this->originalModel !== $this->currentModel) {
-            $modelHeader = ' Cost Estimation ('.$this->getModelName()." - mapped from '{$this->originalModel}') ";
+        $modelHeader = ' Cost Estimation ('.$rates['name'].') ';
+        if ($this->currentModel !== $rates['id']) {
+            $modelHeader = ' Cost Estimation ('.$rates['name']." - mapped from '{$this->currentModel}') ";
         }
 
         $command->line($this->colors['blue_bg'].$this->colors['white'].$this->colors['bold'].$modelHeader.$this->colors['reset']);
-
-        // 기본 입출력 비용
-        $inputCost = $usage['input_tokens'] * $this->getRateInput();
-        $outputCost = $usage['output_tokens'] * $this->getRateOutput();
-
-        // 캐시 관련 비용 계산
-        $cacheCreationCost = $usage['cache_creation_input_tokens'] * $this->getRateCacheWrite();
-        $cacheReadCost = $usage['cache_read_input_tokens'] * $this->getRateCacheRead();
-
-        // 캐시 없이 사용했을 경우 비용
-        $noCacheTotalInputTokens = $usage['input_tokens'] + $usage['cache_creation_input_tokens'] + $usage['cache_read_input_tokens'];
-        $noCacheInputCost = $noCacheTotalInputTokens * $this->getRateInput();
-        $noCacheTotalCost = $noCacheInputCost + $outputCost;
-
-        // 캐시 사용 총 비용
-        $totalCost = $inputCost + $outputCost + $cacheCreationCost + $cacheReadCost;
-
-        // 절약된 비용
-        $savedCost = $noCacheTotalCost - $totalCost;
-        $savedPercentage = $noCacheTotalCost > 0 ? ($savedCost / $noCacheTotalCost) * 100 : 0;
-
-        // 모델 가격 정보
-        $modelRates = $this->getModelRates();
         $command->line($this->colors['gray'].'Model Pricing:'.$this->colors['reset']);
-        $command->line($this->colors['gray'].'  Input: $'.number_format($modelRates['input'], 2).' per million tokens'.$this->colors['reset']);
-        $command->line($this->colors['gray'].'  Output: $'.number_format($modelRates['output'], 2).' per million tokens'.$this->colors['reset']);
-        $command->line($this->colors['gray'].'  Cache Write: $'.number_format($modelRates['cache_write'], 2).' per million tokens (25% premium)'.$this->colors['reset']);
-        $command->line($this->colors['gray'].'  Cache Read: $'.number_format($modelRates['cache_read'], 2).' per million tokens (90% discount)'.$this->colors['reset']);
+        $command->line($this->colors['gray'].'  Input: '.$this->formatRate($rates['input']).$this->colors['reset']);
+        $command->line($this->colors['gray'].'  Output: '.$this->formatRate($rates['output']).$this->colors['reset']);
+        $command->line($this->colors['gray'].'  Cache Write: '.$this->formatRate($rates['cache_write']).$this->colors['reset']);
+        $command->line($this->colors['gray'].'  Cache Read: '.$this->formatRate($rates['cache_read']).$this->colors['reset']);
 
-        // 비용 출력
         $command->line("\n".$this->colors['yellow'].'Your Cost Breakdown'.$this->colors['reset'].':');
-        $command->line('  Regular Input Cost: $'.number_format($inputCost, 6));
-        $command->line('  Cache Creation Cost: $'.number_format($cacheCreationCost, 6).' (25% premium over regular input)');
-        $command->line('  Cache Read Cost: $'.number_format($cacheReadCost, 6).' (90% discount from regular input)');
-        $command->line('  Output Cost: $'.number_format($outputCost, 6));
-        $command->line('  Total Cost: $'.number_format($totalCost, 6));
+        $command->line('  Regular Input Cost: $'.number_format($costs['input'], 6));
+        $command->line('  Cache Creation Cost: $'.number_format($costs['cache_write'], 6));
+        $command->line('  Cache Read Cost: $'.number_format($costs['cache_read'], 6));
+        $command->line('  Output Cost: $'.number_format($costs['output'], 6));
+        $command->line('  Total Cost: $'.number_format($costs['total'], 6));
 
-        // 비용 절약 정보 추가
-        if ($usage['cache_read_input_tokens'] > 0) {
+        if ((int) ($usage['cache_read_input_tokens'] ?? 0) > 0) {
             $command->line("\n".$this->colors['green'].$this->colors['bold'].'Cache Savings'.$this->colors['reset']);
-            $command->line('  Cost without Caching: $'.number_format($noCacheTotalCost, 6));
-            $command->line('  Saved Amount: $'.number_format($savedCost, 6).' ('.number_format($savedPercentage, 2).'% reduction)');
+            $command->line('  Cost without Caching: $'.number_format($costs['no_cache_total'], 6));
+            $command->line('  Saved Amount: $'.number_format($costs['saved'], 6).' ('.number_format($costs['saved_percentage'], 2).'% reduction)');
         }
     }
 
@@ -436,88 +330,66 @@ class TokenUsagePrinter
      */
     public function printModelComparison(Command $command, array $usage): void
     {
+        if ($this->currentModel === null || $this->currentModel === '') {
+            $command->warn('A model is required to compare OpenRouter pricing.');
+
+            return;
+        }
+
         $command->line("\n".str_repeat('─', 80));
         $command->line($this->colors['blue_bg'].$this->colors['white'].$this->colors['bold'].' Model Cost Comparison '.$this->colors['reset']);
 
-        $currentModel = $this->currentModel;
+        $promptTokens = $this->getPromptTokenCount($usage);
+        $currentModelId = $this->getOpenRouterModelId($this->currentModel);
+        $models = array_values(array_unique([$currentModelId, ...self::COMPARISON_MODELS]));
         $comparison = [];
 
-        foreach (self::MODEL_RATES as $model => $rates) {
-            // 임시로 모델 변경
-            $this->currentModel = $model;
+        foreach ($models as $model) {
+            try {
+                $rates = $this->getModelRates($promptTokens, $model);
+                $costs = $this->calculateCosts($rates, $usage);
+            } catch (RuntimeException $exception) {
+                $command->warn($exception->getMessage());
 
-            // 기본 입출력 비용
-            $inputCost = $usage['input_tokens'] * $this->getRateInput();
-            $outputCost = $usage['output_tokens'] * $this->getRateOutput();
+                continue;
+            }
 
-            // 캐시 관련 비용 계산
-            $cacheCreationCost = $usage['cache_creation_input_tokens'] * $this->getRateCacheWrite();
-            $cacheReadCost = $usage['cache_read_input_tokens'] * $this->getRateCacheRead();
-
-            // 캐시 사용 총 비용
-            $totalCost = $inputCost + $outputCost + $cacheCreationCost + $cacheReadCost;
-
-            // 비교 데이터 저장
-            $comparison[$model] = [
+            $comparison[$rates['id']] = [
                 'name' => $rates['name'],
-                'total_cost' => $totalCost,
-                'input_cost' => $inputCost,
-                'output_cost' => $outputCost,
-                'cache_write_cost' => $cacheCreationCost,
-                'cache_read_cost' => $cacheReadCost,
+                'total_cost' => $costs['total'],
             ];
         }
 
-        // 원래 모델로 복원
-        $this->currentModel = $currentModel;
+        $currentModelCost = $comparison[$currentModelId]['total_cost'] ?? 0;
+        uasort($comparison, function ($left, $right): int {
+            return $left['total_cost'] <=> $right['total_cost'];
+        });
 
-        // 테이블 헤더
         $command->line('');
         $command->line($this->colors['bold'].'MODEL'.str_repeat(' ', 20).'TOTAL COST'.str_repeat(' ', 5).'SAVINGS vs CURRENT'.$this->colors['reset']);
         $command->line(str_repeat('─', 80));
 
-        // 현재 모델의 비용
-        $currentModelCost = isset($comparison[$currentModel]) ? $comparison[$currentModel]['total_cost'] : 0;
-
-        // 모델별 비용 비교 테이블 출력 (비용 기준 오름차순 정렬)
-        uasort($comparison, function ($a, $b) {
-            return $a['total_cost'] <=> $b['total_cost'];
-        });
-
         foreach ($comparison as $model => $data) {
-            $isCurrentModel = ($model === $currentModel);
-
-            // 모델 이름 형식
+            $isCurrentModel = $model === $currentModelId;
             $modelName = str_pad($data['name'], 25, ' ');
-            if ($isCurrentModel) {
-                $modelName = $this->colors['green'].'➤ '.$modelName.$this->colors['reset'];
-            } else {
-                $modelName = '  '.$modelName;
-            }
-
-            // 비용 형식
-            $costStr = '$'.str_pad(number_format($data['total_cost'], 6), 12, ' ', STR_PAD_LEFT);
-
-            // 현재 모델과의 비용 차이
+            $modelName = $isCurrentModel
+                ? $this->colors['green'].'➤ '.$modelName.$this->colors['reset']
+                : '  '.$modelName;
+            $cost = '$'.str_pad(number_format($data['total_cost'], 6), 12, ' ', STR_PAD_LEFT);
             $savingsAmount = $currentModelCost - $data['total_cost'];
-            $savingsPercent = $currentModelCost > 0 ? ($savingsAmount / $currentModelCost) * 100 : 0;
+            $savingsPercentage = $currentModelCost > 0 ? ($savingsAmount / $currentModelCost) * 100 : 0;
 
-            $savingsStr = '';
-            if (! $isCurrentModel && $currentModelCost > 0) {
-                if ($savingsAmount > 0) {
-                    // 비용 절감
-                    $savingsStr = $this->colors['green'].str_pad(number_format($savingsAmount, 6), 10, ' ', STR_PAD_LEFT).
-                        ' ('.number_format($savingsPercent, 1).'% less)'.$this->colors['reset'];
-                } else {
-                    // 비용 증가
-                    $savingsStr = $this->colors['red'].str_pad(number_format(abs($savingsAmount), 6), 10, ' ', STR_PAD_LEFT).
-                        ' ('.number_format(abs($savingsPercent), 1).'% more)'.$this->colors['reset'];
-                }
+            if ($isCurrentModel || $currentModelCost <= 0) {
+                $savings = str_pad('—', 25, ' ');
+            } elseif ($savingsAmount > 0) {
+                $savings = $this->colors['green'].str_pad(number_format($savingsAmount, 6), 10, ' ', STR_PAD_LEFT).
+                    ' ('.number_format($savingsPercentage, 1).'% less)'.$this->colors['reset'];
             } else {
-                $savingsStr = str_pad('—', 25, ' ');
+                $savings = $this->colors['red'].str_pad(number_format(abs($savingsAmount), 6), 10, ' ', STR_PAD_LEFT).
+                    ' ('.number_format(abs($savingsPercentage), 1).'% more)'.$this->colors['reset'];
             }
 
-            $command->line($modelName.$costStr.'  '.$savingsStr);
+            $command->line($modelName.$cost.'  '.$savings);
         }
     }
 

--- a/src/AI/Printer/TokenUsagePrinter.php
+++ b/src/AI/Printer/TokenUsagePrinter.php
@@ -13,7 +13,7 @@ class TokenUsagePrinter
 
     public const MODEL_GPT_5_6_SOL = 'openai/gpt-5.6-sol';
 
-    public const MODEL_GEMINI_3_1_PRO = 'google/gemini-3.1-pro-preview';
+    public const MODEL_GEMINI_3_7_FLASH = 'google/gemini-3.7-flash';
 
     /**
      * 지원되는 모델 목록
@@ -56,12 +56,12 @@ class TokenUsagePrinter
             'cache_read' => 0.5,
             'name' => 'GPT-5.6 Sol',
         ],
-        self::MODEL_GEMINI_3_1_PRO => [
-            'input' => 2.0,
-            'output' => 12.0,
-            'cache_write' => 0.375,
-            'cache_read' => 0.2,
-            'name' => 'Gemini 3.1 Pro Preview',
+        self::MODEL_GEMINI_3_7_FLASH => [
+            'input' => 0.375,
+            'output' => 1.875,
+            'cache_write' => 0.020833,
+            'cache_read' => 0.0375,
+            'name' => 'Gemini 3.7 Flash',
         ],
 
         // Opus models

--- a/src/Console/TestTranslateCommand.php
+++ b/src/Console/TestTranslateCommand.php
@@ -63,7 +63,11 @@ class TestTranslateCommand extends Command
         }
 
         if ($useExtendedThinking) {
-            config(['ai-translator.ai.reasoning' => ['effort' => 'high']]);
+            // One CLI flag configures both OpenRouter reasoning and the retained direct Anthropic path.
+            config([
+                'ai-translator.ai.reasoning' => ['effort' => 'high'],
+                'ai-translator.ai.use_extended_thinking' => true,
+            ]);
         }
 
         // 토큰 사용량 추적을 위한 변수

--- a/src/Console/TestTranslateCommand.php
+++ b/src/Console/TestTranslateCommand.php
@@ -16,7 +16,7 @@ class TestTranslateCommand extends Command
                           {target_language=ko : Target language code (ex: ko)}
                           {--text= : Text to translate}
                           {--rules=* : Additional rules}
-                          {--extended-thinking : Use Extended Thinking feature (only supported for claude-3-7 models)}
+                          {--extended-thinking : Request high reasoning effort from supported models}
                           {--debug : Enable debug mode with detailed logging}
                           {--show-xml : Show raw XML response in the output}';
 
@@ -63,7 +63,7 @@ class TestTranslateCommand extends Command
         }
 
         if ($useExtendedThinking) {
-            config(['ai-translator.ai.use_extended_thinking' => true]);
+            config(['ai-translator.ai.reasoning' => ['effort' => 'high']]);
         }
 
         // 토큰 사용량 추적을 위한 변수

--- a/src/Console/TranslateFileCommand.php
+++ b/src/Console/TranslateFileCommand.php
@@ -82,11 +82,6 @@ class TranslateFileCommand extends Command
             $this->info("Target language: {$targetLanguage}");
             $this->info('Total strings: '.count($strings));
 
-            config(['ai-translator.ai.model' => 'claude-3-7-sonnet-latest']);
-            config(['ai-translator.ai.max_tokens' => 64000]);
-            // config(['ai-translator.ai.model' => 'claude-3-5-sonnet-latest']);
-            // config(['ai-translator.ai.max_tokens' => 8192]);
-            config(['ai-translator.ai.use_extended_thinking' => false]);
             config(['ai-translator.ai.disable_stream' => false]);
 
             // Get global translation context

--- a/tests/Feature/Console/TestTranslateCommandTest.php
+++ b/tests/Feature/Console/TestTranslateCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\ValueObjects\Usage;
+
+use function Pest\Laravel\artisan;
+
+test('extended thinking configures OpenRouter reasoning and direct Anthropic thinking', function () {
+    config()->set('ai-translator.ai.api_key', 'test-openrouter-key');
+    Http::fake([
+        'https://openrouter.ai/api/v1/models' => Http::response([
+            'data' => [[
+                'id' => 'anthropic/claude-opus-5',
+                'name' => 'Claude Opus 5',
+                'pricing' => [
+                    'prompt' => '0.000005',
+                    'completion' => '0.000025',
+                ],
+            ]],
+        ]),
+    ]);
+    $fake = Prism::fake([
+        TextResponseFake::make()
+            ->withText('<translations><item><key>Test.test</key><trx><![CDATA[안녕하세요]]></trx></item></translations>')
+            ->withUsage(new Usage(12, 8)),
+    ]);
+
+    artisan('ai-translator:test-translate', [
+        '--text' => 'Hello',
+        '--extended-thinking' => true,
+    ])->assertSuccessful();
+
+    expect(config('ai-translator.ai.reasoning'))->toBe(['effort' => 'high'])
+        ->and(config('ai-translator.ai.use_extended_thinking'))->toBeTrue();
+    $fake->assertRequest(function (array $requests): void {
+        expect($requests)->toHaveCount(1)
+            ->and($requests[0]->providerOptions('reasoning'))->toBe(['effort' => 'high']);
+    });
+});

--- a/tests/Feature/Console/TranslateFileCommandTest.php
+++ b/tests/Feature/Console/TranslateFileCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\ValueObjects\Usage;
+
+use function Pest\Laravel\artisan;
+
+test('uses the configured OpenRouter model when translating one file', function () {
+    $sourceFile = tempnam(sys_get_temp_dir(), 'laravel-ai-translator-');
+    if ($sourceFile === false) {
+        throw new RuntimeException('Unable to create temporary translation file.');
+    }
+
+    $outputFile = pathinfo($sourceFile, PATHINFO_DIRNAME).'/'
+        .pathinfo($sourceFile, PATHINFO_FILENAME).'-ko.php';
+    file_put_contents($sourceFile, "<?php return ['greeting' => 'Hello'];");
+
+    $key = pathinfo($sourceFile, PATHINFO_FILENAME).'.greeting';
+    $fake = Prism::fake([
+        TextResponseFake::make()
+            ->withText("<translations><item><key>{$key}</key><trx><![CDATA[안녕하세요]]></trx></item></translations>")
+            ->withUsage(new Usage(10, 5)),
+    ]);
+    config()->set('ai-translator.ai.api_key', 'test-openrouter-key');
+
+    try {
+        artisan('ai-translator:translate-file', [
+            'file' => $sourceFile,
+            '--target-language' => 'ko',
+        ])->assertSuccessful();
+
+        $fake->assertRequest(function (array $requests): void {
+            expect($requests)->toHaveCount(1)
+                ->and($requests[0]->provider())->toBe('openrouter')
+                ->and($requests[0]->model())->toBe('anthropic/claude-opus-5');
+        });
+    } finally {
+        foreach ([$sourceFile, $outputFile] as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
+});

--- a/tests/Feature/Console/TranslateJsonTest.php
+++ b/tests/Feature/Console/TranslateJsonTest.php
@@ -9,15 +9,17 @@ use function Pest\Laravel\artisan;
 
 function checkApiKeysExistForJsonFeature(): bool
 {
-    return ! empty(env('OPENAI_API_KEY')) || ! empty(env('ANTHROPIC_API_KEY'));
+    $key = env('OPENROUTER_API_KEY');
+
+    return is_string($key) && $key !== '' && ! str_starts_with($key, 'your-');
 }
 
 beforeEach(function () {
     $this->hasApiKeys = checkApiKeysExistForJsonFeature();
     $this->testJsonPath = __DIR__.'/../../Fixtures/lang_json';
-    Config::set('ai-translator.ai.provider', 'anthropic');
-    Config::set('ai-translator.ai.model', 'claude-3-haiku-20240307');
-    Config::set('ai-translator.ai.api_key', env('ANTHROPIC_API_KEY'));
+    Config::set('ai-translator.ai.provider', 'openrouter');
+    Config::set('ai-translator.ai.model', 'anthropic/claude-opus-5');
+    Config::set('ai-translator.ai.api_key', env('OPENROUTER_API_KEY'));
     Config::set('ai-translator.source_directory', $this->testJsonPath);
     Config::set('ai-translator.source_locale', 'en');
 

--- a/tests/Feature/Console/TranslateStringsTest.php
+++ b/tests/Feature/Console/TranslateStringsTest.php
@@ -11,7 +11,9 @@ use function Pest\Laravel\artisan;
 
 function checkApiKeysExistForFeature(): bool
 {
-    return ! empty(env('OPENAI_API_KEY')) && ! empty(env('ANTHROPIC_API_KEY'));
+    $key = env('OPENROUTER_API_KEY');
+
+    return is_string($key) && $key !== '' && ! str_starts_with($key, 'your-');
 }
 
 beforeEach(function () {
@@ -21,8 +23,6 @@ beforeEach(function () {
     // Set up test language file directory
     $this->testLangPath = __DIR__.'/../../Fixtures/lang';
 
-    // For testing purpose, we use claude-3-haiku-20240307 model. (It's faster and cheaper than other models.)
-    Config::set('ai-translator.model', 'claude-3-haiku-20240307');
     Config::set('ai-translator.source_directory', $this->testLangPath);
     Config::set('ai-translator.source_locale', 'en');
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Kargnas\LaravelAiTranslator\Tests;
 
 use Kargnas\LaravelAiTranslator\ServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Prism\Prism\PrismServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -20,6 +21,7 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app): array
     {
         return [
+            PrismServiceProvider::class,
             ServiceProvider::class,
         ];
     }

--- a/tests/Unit/AI/AIProviderTest.php
+++ b/tests/Unit/AI/AIProviderTest.php
@@ -62,7 +62,7 @@ test('can translate strings using OpenRouter', function () {
     }
 
     config()->set('ai-translator.ai.provider', 'openrouter');
-    config()->set('ai-translator.ai.model', 'openai/gpt-5.6-sol');
+    config()->set('ai-translator.ai.model', 'google/gemini-3.7-flash');
     config()->set('ai-translator.ai.api_key', env('OPENROUTER_API_KEY'));
     config()->set('ai-translator.ai.disable_stream', true);
 
@@ -125,7 +125,7 @@ test('can translate strings using Gemini', function () {
     }
 
     config()->set('ai-translator.ai.provider', 'gemini');
-    config()->set('ai-translator.ai.model', 'gemini-3.1-pro-preview');
+    config()->set('ai-translator.ai.model', 'gemini-3.7-flash');
     config()->set('ai-translator.ai.api_key', env('GEMINI_API_KEY'));
     config()->set('ai-translator.ai.max_tokens', 65536);
 

--- a/tests/Unit/AI/AIProviderTest.php
+++ b/tests/Unit/AI/AIProviderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kargnas\LaravelAiTranslator\AI\AIProvider;
+use Kargnas\LaravelAiTranslator\Enums\TranslationStatus;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\Testing\TextResponseFake;
 use Prism\Prism\Text\Request;
@@ -143,21 +144,26 @@ test('can translate strings using Gemini', function () {
 test('uses OpenRouter with the default frontier model', function () {
     config()->set('ai-translator.ai.api_key', 'test-openrouter-key');
     config()->set('ai-translator.ai.disable_stream', true);
+    config()->set('ai-translator.ai.temperature', 0.2);
+    config()->set('ai-translator.ai.max_tokens', 4096);
     config()->set('ai-translator.ai.reasoning', ['effort' => 'high']);
 
     $fake = Prism::fake([
         TextResponseFake::make()
             ->withText('<translations><item><key>test.greeting</key><trx><![CDATA[안녕하세요]]></trx></item></translations>')
-            ->withUsage(new Usage(12, 8)),
+            ->withUsage(new Usage(12, 8, cacheReadInputTokens: 4)),
     ]);
 
     $usageEvents = [];
+    $translationEvents = [];
     $provider = (new AIProvider(
         'test.php',
         ['greeting' => 'Hello'],
         'en',
         'ko'
-    ))->setOnTokenUsage(function (array $usage) use (&$usageEvents): void {
+    ))->setOnTranslated(function ($item, string $status) use (&$translationEvents): void {
+        $translationEvents[] = $status;
+    })->setOnTokenUsage(function (array $usage) use (&$usageEvents): void {
         $usageEvents[] = $usage;
     });
 
@@ -167,11 +173,17 @@ test('uses OpenRouter with the default frontier model', function () {
         ->and($result[0]->key)->toBe('greeting')
         ->and($result[0]->translated)->toBe('안녕하세요')
         ->and($provider->getTokenUsage())->toMatchArray([
-            'input_tokens' => 12,
+            'input_tokens' => 8,
             'output_tokens' => 8,
+            'cache_creation_input_tokens' => 0,
+            'cache_read_input_tokens' => 4,
             'total_tokens' => 20,
         ])
-        ->and(array_column($usageEvents, 'final'))->toBe([false, true]);
+        ->and(array_column($usageEvents, 'final'))->toBe([false, true])
+        ->and($translationEvents)->toBe([
+            TranslationStatus::STARTED,
+            TranslationStatus::COMPLETED,
+        ]);
 
     $fake->assertProviderConfig(['api_key' => 'test-openrouter-key']);
     $fake->assertRequest(function (array $requests): void {
@@ -179,8 +191,38 @@ test('uses OpenRouter with the default frontier model', function () {
             ->and($requests[0])->toBeInstanceOf(Request::class)
             ->and($requests[0]->provider())->toBe('openrouter')
             ->and($requests[0]->model())->toBe('anthropic/claude-opus-5')
-            ->and($requests[0]->maxTokens())->toBe(128000)
+            ->and($requests[0]->temperature())->toBe(0.2)
+            ->and($requests[0]->maxTokens())->toBe(4096)
             ->and($requests[0]->providerOptions('reasoning'))->toBe(['effort' => 'high']);
+    });
+});
+
+test('omits unconfigured optional OpenRouter parameters', function () {
+    config()->set('ai-translator.ai.api_key', 'test-openrouter-key');
+    config()->set('ai-translator.ai.disable_stream', true);
+    config()->offsetUnset('ai-translator.ai.temperature');
+    config()->offsetUnset('ai-translator.ai.max_tokens');
+    config()->offsetUnset('ai-translator.ai.reasoning');
+
+    $fake = Prism::fake([
+        TextResponseFake::make()
+            ->withText('<translations><item><key>test.greeting</key><trx><![CDATA[안녕하세요]]></trx></item></translations>')
+            ->withUsage(new Usage(12, 8)),
+    ]);
+
+    $result = (new AIProvider(
+        'test.php',
+        ['greeting' => 'Hello'],
+        'en',
+        'ko'
+    ))->translate();
+
+    expect($result)->toHaveCount(1);
+    $fake->assertRequest(function (array $requests): void {
+        expect($requests)->toHaveCount(1)
+            ->and($requests[0]->temperature())->toBeNull()
+            ->and($requests[0]->maxTokens())->toBeNull()
+            ->and($requests[0]->providerOptions())->toBe([]);
     });
 });
 
@@ -196,12 +238,15 @@ test('streams OpenRouter translations through existing callbacks', function () {
     ])->withFakeChunkSize(9);
 
     $progress = [];
+    $translationEvents = [];
     $provider = (new AIProvider(
         'test.php',
         ['greeting' => 'Hello'],
         'en',
         'ko'
-    ))->setOnProgress(function (string $chunk) use (&$progress): void {
+    ))->setOnTranslated(function ($item, string $status) use (&$translationEvents): void {
+        $translationEvents[] = $status;
+    })->setOnProgress(function (string $chunk) use (&$progress): void {
         $progress[] = $chunk;
     });
 
@@ -209,7 +254,11 @@ test('streams OpenRouter translations through existing callbacks', function () {
 
     expect($result)->toHaveCount(1)
         ->and($result[0]->translated)->toBe('안녕하세요')
-        ->and(implode('', $progress))->toContain('<translations>');
+        ->and(implode('', $progress))->toContain('<translations>')
+        ->and($translationEvents)->toBe([
+            TranslationStatus::STARTED,
+            TranslationStatus::COMPLETED,
+        ]);
 });
 
 test('throws exception for unsupported provider', function () {

--- a/tests/Unit/AI/AIProviderTest.php
+++ b/tests/Unit/AI/AIProviderTest.php
@@ -1,26 +1,43 @@
 <?php
 
 use Kargnas\LaravelAiTranslator\AI\AIProvider;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\Text\Request;
+use Prism\Prism\ValueObjects\Usage;
 
 function providerKeys(): array
 {
+    $hasKey = function (string $name): bool {
+        $key = env($name);
+
+        return is_string($key) && $key !== '' && ! str_starts_with($key, 'your-');
+    };
+
     return [
-        'openai' => ! empty(env('OPENAI_API_KEY')),
-        'anthropic' => ! empty(env('ANTHROPIC_API_KEY')),
-        'gemini' => ! empty(env('GEMINI_API_KEY')),
+        'openrouter' => $hasKey('OPENROUTER_API_KEY'),
+        'openai' => $hasKey('OPENAI_API_KEY'),
+        'anthropic' => $hasKey('ANTHROPIC_API_KEY'),
+        'gemini' => $hasKey('GEMINI_API_KEY'),
     ];
 }
 
 beforeEach(function () {
     $keys = providerKeys();
+    $this->hasOpenRouter = $keys['openrouter'];
     $this->hasOpenAI = $keys['openai'];
     $this->hasAnthropic = $keys['anthropic'];
     $this->hasGemini = $keys['gemini'];
 });
 
 test('environment variables are loaded from .env.testing', function () {
-    if (! ($this->hasOpenAI || $this->hasAnthropic || $this->hasGemini)) {
+    if (! ($this->hasOpenRouter || $this->hasOpenAI || $this->hasAnthropic || $this->hasGemini)) {
         $this->markTestSkipped('API keys not found in environment. Skipping test.');
+    }
+
+    if ($this->hasOpenRouter) {
+        expect(env('OPENROUTER_API_KEY'))->not()->toBeNull()
+            ->toBeString();
     }
 
     if ($this->hasOpenAI) {
@@ -39,13 +56,35 @@ test('environment variables are loaded from .env.testing', function () {
     }
 });
 
+test('can translate strings using OpenRouter', function () {
+    if (! $this->hasOpenRouter) {
+        $this->markTestSkipped('OpenRouter API key not found in environment. Skipping test.');
+    }
+
+    config()->set('ai-translator.ai.provider', 'openrouter');
+    config()->set('ai-translator.ai.model', 'openai/gpt-5.6-sol');
+    config()->set('ai-translator.ai.api_key', env('OPENROUTER_API_KEY'));
+    config()->set('ai-translator.ai.disable_stream', true);
+
+    $provider = new AIProvider(
+        'test.php',
+        ['greeting' => 'Hello, world!'],
+        'en',
+        'ko'
+    );
+
+    $result = $provider->translate();
+
+    expect($result)->toBeArray()->toHaveCount(1);
+});
+
 test('can translate strings using OpenAI', function () {
     if (! $this->hasOpenAI) {
         $this->markTestSkipped('OpenAI API key not found in environment. Skipping test.');
     }
 
     config()->set('ai-translator.ai.provider', 'openai');
-    config()->set('ai-translator.ai.model', 'gpt-4o-mini');
+    config()->set('ai-translator.ai.model', 'gpt-5.6-sol');
     config()->set('ai-translator.ai.api_key', env('OPENAI_API_KEY'));
 
     $provider = new AIProvider(
@@ -65,8 +104,9 @@ test('can translate strings using Anthropic', function () {
     }
 
     config()->set('ai-translator.ai.provider', 'anthropic');
-    config()->set('ai-translator.ai.model', 'claude-3-haiku-20240307');
+    config()->set('ai-translator.ai.model', 'claude-opus-5');
     config()->set('ai-translator.ai.api_key', env('ANTHROPIC_API_KEY'));
+    config()->set('ai-translator.ai.max_tokens', 128000);
 
     $provider = new AIProvider(
         'test.php',
@@ -85,9 +125,9 @@ test('can translate strings using Gemini', function () {
     }
 
     config()->set('ai-translator.ai.provider', 'gemini');
-    config()->set('ai-translator.ai.model', 'gemini-2.5-pro');
-    config()->set('ai-translator.ai.model', 'gemini-2.5-flash');
+    config()->set('ai-translator.ai.model', 'gemini-3.1-pro-preview');
     config()->set('ai-translator.ai.api_key', env('GEMINI_API_KEY'));
+    config()->set('ai-translator.ai.max_tokens', 65536);
 
     $provider = new AIProvider(
         'test.php',
@@ -98,6 +138,78 @@ test('can translate strings using Gemini', function () {
 
     $result = $provider->translate();
     expect($result)->toBeArray()->toHaveCount(1);
+});
+
+test('uses OpenRouter with the default frontier model', function () {
+    config()->set('ai-translator.ai.api_key', 'test-openrouter-key');
+    config()->set('ai-translator.ai.disable_stream', true);
+    config()->set('ai-translator.ai.reasoning', ['effort' => 'high']);
+
+    $fake = Prism::fake([
+        TextResponseFake::make()
+            ->withText('<translations><item><key>test.greeting</key><trx><![CDATA[안녕하세요]]></trx></item></translations>')
+            ->withUsage(new Usage(12, 8)),
+    ]);
+
+    $usageEvents = [];
+    $provider = (new AIProvider(
+        'test.php',
+        ['greeting' => 'Hello'],
+        'en',
+        'ko'
+    ))->setOnTokenUsage(function (array $usage) use (&$usageEvents): void {
+        $usageEvents[] = $usage;
+    });
+
+    $result = $provider->translate();
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->key)->toBe('greeting')
+        ->and($result[0]->translated)->toBe('안녕하세요')
+        ->and($provider->getTokenUsage())->toMatchArray([
+            'input_tokens' => 12,
+            'output_tokens' => 8,
+            'total_tokens' => 20,
+        ])
+        ->and(array_column($usageEvents, 'final'))->toBe([false, true]);
+
+    $fake->assertProviderConfig(['api_key' => 'test-openrouter-key']);
+    $fake->assertRequest(function (array $requests): void {
+        expect($requests)->toHaveCount(1)
+            ->and($requests[0])->toBeInstanceOf(Request::class)
+            ->and($requests[0]->provider())->toBe('openrouter')
+            ->and($requests[0]->model())->toBe('anthropic/claude-opus-5')
+            ->and($requests[0]->maxTokens())->toBe(128000)
+            ->and($requests[0]->providerOptions('reasoning'))->toBe(['effort' => 'high']);
+    });
+});
+
+test('streams OpenRouter translations through existing callbacks', function () {
+    config()->set('ai-translator.ai.provider', 'openrouter');
+    config()->set('ai-translator.ai.model', 'openai/gpt-5.6-sol');
+    config()->set('ai-translator.ai.api_key', 'test-openrouter-key');
+    config()->set('ai-translator.ai.disable_stream', false);
+
+    Prism::fake([
+        TextResponseFake::make()
+            ->withText('<translations><item><key>test.greeting</key><trx><![CDATA[안녕하세요]]></trx></item></translations>'),
+    ])->withFakeChunkSize(9);
+
+    $progress = [];
+    $provider = (new AIProvider(
+        'test.php',
+        ['greeting' => 'Hello'],
+        'en',
+        'ko'
+    ))->setOnProgress(function (string $chunk) use (&$progress): void {
+        $progress[] = $chunk;
+    });
+
+    $result = $provider->translate();
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->translated)->toBe('안녕하세요')
+        ->and(implode('', $progress))->toContain('<translations>');
 });
 
 test('throws exception for unsupported provider', function () {

--- a/tests/Unit/AI/TokenUsagePrinterTest.php
+++ b/tests/Unit/AI/TokenUsagePrinterTest.php
@@ -2,28 +2,165 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Console\OutputStyle;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Kargnas\LaravelAiTranslator\AI\Printer\TokenUsagePrinter;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-test('reports current frontier model pricing', function (string $model, string $name, string $totalCost) {
+function openRouterPricingFixture(): array
+{
+    return [
+        'data' => [
+            [
+                'id' => 'anthropic/claude-opus-5',
+                'canonical_slug' => 'anthropic/claude-opus-5-20260723',
+                'name' => 'Claude Opus 5',
+                'context_length' => 1_048_576,
+                'pricing' => [
+                    'prompt' => '0.000005',
+                    'completion' => '0.000025',
+                    'input_cache_read' => '0.0000005',
+                    'input_cache_write' => '0.00000625',
+                ],
+                'top_provider' => ['context_length' => 1_048_576, 'max_completion_tokens' => 128_000],
+                'supported_parameters' => ['reasoning', 'max_tokens'],
+            ],
+            [
+                'id' => 'openai/gpt-5.6-sol',
+                'canonical_slug' => 'openai/gpt-5.6-sol-20260709',
+                'name' => 'OpenAI: GPT-5.6 Sol',
+                'context_length' => 1_048_576,
+                'pricing' => [
+                    'prompt' => '0.000005',
+                    'completion' => '0.00003',
+                    'input_cache_read' => '0.0000005',
+                    'input_cache_write' => '0.00000625',
+                    'overrides' => [
+                        [
+                            'min_prompt_tokens' => 272_000,
+                            'prompt' => '0.00001',
+                            'completion' => '0.000045',
+                            'input_cache_read' => '0.000001',
+                            'input_cache_write' => '0.0000125',
+                        ],
+                    ],
+                ],
+                'top_provider' => ['context_length' => 1_048_576, 'max_completion_tokens' => 128_000],
+                'supported_parameters' => ['reasoning', 'max_tokens'],
+            ],
+            [
+                'id' => 'google/gemini-3.7-flash',
+                'canonical_slug' => 'google/gemini-3.7-flash-20260813',
+                'name' => 'Google: Gemini 3.7 Flash',
+                'context_length' => 1_048_576,
+                'pricing' => [
+                    'prompt' => '0.000000375',
+                    'completion' => '0.000001875',
+                    'input_cache_read' => '0.0000000375',
+                    'input_cache_write' => '0.0000000208333333333333',
+                ],
+                'top_provider' => ['context_length' => 1_048_576, 'max_completion_tokens' => 65_536],
+                'supported_parameters' => ['reasoning', 'max_tokens'],
+            ],
+        ],
+    ];
+}
+
+function pricingCommand(): array
+{
     $command = new class extends Command {};
     $output = new BufferedOutput;
     $command->setOutput(new OutputStyle(new ArrayInput([]), $output));
 
-    (new TokenUsagePrinter($model))->printCostEstimation($command, [
-        'input_tokens' => 100_000,
-        'output_tokens' => 100_000,
+    return [$command, $output];
+}
+
+function pricingUsage(int $inputTokens = 100_000, int $outputTokens = 100_000): array
+{
+    return [
+        'input_tokens' => $inputTokens,
+        'output_tokens' => $outputTokens,
         'cache_creation_input_tokens' => 0,
         'cache_read_input_tokens' => 0,
-        'total_tokens' => 200_000,
+        'total_tokens' => $inputTokens + $outputTokens,
+    ];
+}
+
+beforeEach(function () {
+    Cache::flush();
+    Http::preventStrayRequests();
+});
+
+test('uses OpenRouter pricing for OpenRouter and direct providers', function (string $provider, string $model, string $name, string $totalCost) {
+    config()->set('ai-translator.ai.provider', $provider);
+    Http::fake([
+        'https://openrouter.ai/api/v1/models' => Http::response(openRouterPricingFixture()),
     ]);
+    [$command, $output] = pricingCommand();
+
+    (new TokenUsagePrinter($model))->printCostEstimation($command, pricingUsage());
 
     expect($output->fetch())
-        ->toContain("Cost Estimation ({$name})")
+        ->toContain("Cost Estimation ({$name}")
         ->toContain("Total Cost: \${$totalCost}");
+    Http::assertSentCount(1);
 })->with([
-    ['anthropic/claude-opus-5', 'Claude Opus 5', '3.000000'],
-    ['openai/gpt-5.6-sol', 'GPT-5.6 Sol', '3.500000'],
-    ['google/gemini-3.7-flash', 'Gemini 3.7 Flash', '0.225000'],
+    ['openrouter', 'anthropic/claude-opus-5', 'Claude Opus 5', '3.000000'],
+    ['openai', 'gpt-5.6-sol', 'OpenAI: GPT-5.6 Sol', '3.500000'],
+    ['anthropic', 'claude-opus-5', 'Claude Opus 5', '3.000000'],
+    ['gemini', 'gemini-3.7-flash', 'Google: Gemini 3.7 Flash', '0.225000'],
 ]);
+
+test('caches the OpenRouter catalog across full reports', function () {
+    config()->set('ai-translator.ai.provider', 'openrouter');
+    Http::fake([
+        'https://openrouter.ai/api/v1/models' => Http::response(openRouterPricingFixture()),
+    ]);
+    [$command] = pricingCommand();
+
+    (new TokenUsagePrinter('openai/gpt-5.6-sol'))->printFullReport($command, pricingUsage());
+    (new TokenUsagePrinter('openai/gpt-5.6-sol'))->printFullReport($command, pricingUsage());
+
+    Http::assertSentCount(1);
+});
+
+test('applies OpenRouter prompt-token pricing overrides', function () {
+    config()->set('ai-translator.ai.provider', 'openai');
+    Http::fake([
+        'https://openrouter.ai/api/v1/models' => Http::response(openRouterPricingFixture()),
+    ]);
+    [$command, $output] = pricingCommand();
+
+    (new TokenUsagePrinter('gpt-5.6-sol'))->printCostEstimation($command, pricingUsage(300_000, 100_000));
+
+    expect($output->fetch())->toContain('Total Cost: $7.500000');
+});
+
+test('reports unavailable pricing without a model fallback', function () {
+    config()->set('ai-translator.ai.provider', 'openrouter');
+    Http::fake([
+        'https://openrouter.ai/api/v1/models' => Http::response(['data' => []]),
+    ]);
+    [$command, $output] = pricingCommand();
+
+    (new TokenUsagePrinter('unknown/model'))->printCostEstimation($command, pricingUsage());
+
+    expect($output->fetch())
+        ->toContain("Pricing for 'unknown/model' is not available from OpenRouter.")
+        ->not->toContain('Total Cost:');
+});
+
+test('reports OpenRouter catalog failures without a model fallback', function () {
+    config()->set('ai-translator.ai.provider', 'anthropic');
+    Http::fake([
+        'https://openrouter.ai/api/v1/models' => Http::response([], 503),
+    ]);
+    [$command, $output] = pricingCommand();
+
+    (new TokenUsagePrinter('claude-opus-5'))->printCostEstimation($command, pricingUsage());
+
+    expect($output->fetch())
+        ->toContain('OpenRouter pricing request failed with HTTP 503.')
+        ->not->toContain('Total Cost:');
+});

--- a/tests/Unit/AI/TokenUsagePrinterTest.php
+++ b/tests/Unit/AI/TokenUsagePrinterTest.php
@@ -164,3 +164,17 @@ test('reports OpenRouter catalog failures without a model fallback', function ()
         ->toContain('OpenRouter pricing request failed with HTTP 503.')
         ->not->toContain('Total Cost:');
 });
+
+test('reports an OpenRouter catalog failure once across a full report', function () {
+    config()->set('ai-translator.ai.provider', 'anthropic');
+    Http::fake([
+        'https://openrouter.ai/api/v1/models' => Http::response([], 503),
+    ]);
+    [$command, $output] = pricingCommand();
+
+    (new TokenUsagePrinter('claude-opus-5'))->printFullReport($command, pricingUsage());
+
+    $report = $output->fetch();
+    expect(substr_count($report, 'OpenRouter pricing request failed with HTTP 503.'))->toBe(1)
+        ->and($report)->not->toContain('Model Cost Comparison');
+});

--- a/tests/Unit/AI/TokenUsagePrinterTest.php
+++ b/tests/Unit/AI/TokenUsagePrinterTest.php
@@ -25,5 +25,5 @@ test('reports current frontier model pricing', function (string $model, string $
 })->with([
     ['anthropic/claude-opus-5', 'Claude Opus 5', '3.000000'],
     ['openai/gpt-5.6-sol', 'GPT-5.6 Sol', '3.500000'],
-    ['google/gemini-3.1-pro-preview', 'Gemini 3.1 Pro Preview', '1.400000'],
+    ['google/gemini-3.7-flash', 'Gemini 3.7 Flash', '0.225000'],
 ]);

--- a/tests/Unit/AI/TokenUsagePrinterTest.php
+++ b/tests/Unit/AI/TokenUsagePrinterTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Console\Command;
+use Illuminate\Console\OutputStyle;
+use Kargnas\LaravelAiTranslator\AI\Printer\TokenUsagePrinter;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+test('reports current frontier model pricing', function (string $model, string $name, string $totalCost) {
+    $command = new class extends Command {};
+    $output = new BufferedOutput;
+    $command->setOutput(new OutputStyle(new ArrayInput([]), $output));
+
+    (new TokenUsagePrinter($model))->printCostEstimation($command, [
+        'input_tokens' => 100_000,
+        'output_tokens' => 100_000,
+        'cache_creation_input_tokens' => 0,
+        'cache_read_input_tokens' => 0,
+        'total_tokens' => 200_000,
+    ]);
+
+    expect($output->fetch())
+        ->toContain("Cost Estimation ({$name})")
+        ->toContain("Total Cost: \${$totalCost}");
+})->with([
+    ['anthropic/claude-opus-5', 'Claude Opus 5', '3.000000'],
+    ['openai/gpt-5.6-sol', 'GPT-5.6 Sol', '3.500000'],
+    ['google/gemini-3.1-pro-preview', 'Gemini 3.1 Pro Preview', '1.400000'],
+]);


### PR DESCRIPTION
## Problem

The package needed OpenRouter as the default provider without removing direct OpenAI, Anthropic, or Gemini support. Cost estimates were also tied to a hardcoded model table, and unknown models silently fell back to unrelated Claude pricing.

## Changes

- Added the PrismPHP OpenRouter path and made OpenRouter the default provider.
- Preserved the existing direct OpenAI, Anthropic, and Gemini translation paths.
- Set `anthropic/claude-opus-5` as the default model and updated the GPT-5.6 Sol and Gemini 3.7 Flash examples.
- Replaced hardcoded token prices with the public OpenRouter model catalog for every translation provider.
- Cached the OpenRouter catalog for six hours to avoid downloading it for every cost report.
- Normalized bare direct-provider model IDs only for pricing lookup; direct API request model IDs are unchanged.
- Applied OpenRouter prompt-token pricing overrides, including long-context tiers.
- Removed fuzzy pricing matches and unrelated-model fallbacks. Missing or unavailable prices now produce an explicit warning and skip the estimate.
- Never sends direct-provider credentials to the OpenRouter catalog endpoint.
- Restored translation status callbacks, cache token accounting, and direct Anthropic `--extended-thinking` behavior.
- Updated the README and published configuration to state that OpenRouter is the default, not the only supported provider.
- Updated the runtime requirements to PHP 8.2+ and Laravel 11+ for PrismPHP compatibility.

## Compatibility

- The minimum PHP version is now 8.2.
- Supported Laravel versions are 11, 12, and 13.
- `OPENROUTER_API_KEY` is the default API key variable.
- Direct providers continue to use `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY` when selected.

## Verification

- `./vendor/bin/pest --no-coverage`: 93 passed, 13 skipped, 301 assertions
- `./vendor/bin/phpstan analyse --no-progress`: passed
- `composer audit --no-interaction`: no advisories
- Pint on all changed PHP files: passed
- `git diff --check`: passed
- Real OpenRouter smoke with `google/gemini-3.7-flash`: passed
- Laravel 13 host smoke with OpenRouter and `google/gemini-3.7-flash`: translation and live-catalog cost report passed
- Cache persistence verified in the Laravel database cache store

## Test coverage

Focused provider tests cover optional request parameters, streaming and non-streaming callbacks, cache usage mapping, and direct Anthropic thinking compatibility. Focused pricing tests cover OpenRouter and direct-provider model resolution, cross-instance catalog caching, prompt-token pricing overrides, unavailable models, and catalog HTTP failures without fallbacks. Direct-provider live translation tests remain API-key gated; their dispatch paths are preserved and their pricing mappings are deterministic tests.